### PR TITLE
Dustgeom

### DIFF
--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -707,32 +707,36 @@ contains
        mphi_ = mom(phi_)
        h1x^L=ixO^L-kr(1,^D); {^NOONED h2x^L=ixO^L-kr(2,^D);}
        ! s[mr]=((mtheta**2+mphi**2)/rho+2*p)/r
-       call hd_get_pthermal(wCT,x,ixI^L,ixO^L,tmp1)
-       tmp(ixO^S)=tmp1(ixO^S)*x(ixO^S,1) &
-            *(block%surfaceC(ixO^S,1)-block%surfaceC(h1x^S,1)) &
+       call hd_get_pthermal(wCT, x, ixI^L, ixO^L, tmp1)
+       tmp(ixO^S) = tmp1(ixO^S) * x(ixO^S, 1) &
+            *(block%surfaceC(ixO^S, 1) - block%surfaceC(h1x^S, 1)) &
             /block%dvolume(ixO^S)
-       if(ndir>1) then
-         do idir=2,ndir
-           tmp(ixO^S)=tmp(ixO^S)+wCT(ixO^S,mom(idir))**2/wCT(ixO^S,rho_)
+       if (ndir > 1) then
+         do idir = 2, ndir
+           tmp(ixO^S) = tmp(ixO^S) + wCT(ixO^S, mom(idir))**2 / wCT(ixO^S, rho_)
          end do
        end if
-       w(ixO^S,mr_)=w(ixO^S,mr_)+qdt*tmp(ixO^S)/x(ixO^S,1)
+       w(ixO^S, mr_) = w(ixO^S, mr_) + qdt*tmp(ixO^S) / x(ixO^S, 1)
 
        {^NOONED
        ! s[mtheta]=-(mr*mtheta/rho)/r+cot(theta)*(mphi**2/rho+p)/r
-       tmp(ixO^S)=tmp1(ixO^S)*x(ixO^S,1) &
-            *(block%surfaceC(ixO^S,2)-block%surfaceC(h2x^S,2)) &
-            /block%dvolume(ixO^S)
-       if(ndir==3) tmp(ixO^S)=tmp(ixO^S)+(wCT(ixO^S,mom(3))**2/wCT(ixO^S,rho_))/tan(x(ixO^S,2))
-       if (.not. angmomfix) tmp(ixO^S)=tmp(ixO^S)-(wCT(ixO^S,mom(2))*wCT(ixO^S,mr_))/wCT(ixO^S,rho_)
-       w(ixO^S,mom(2))=w(ixO^S,mom(2))+qdt*tmp(ixO^S)/x(ixO^S,1)
+       tmp(ixO^S) = tmp1(ixO^S) * x(ixO^S, 1) &
+            * (block%surfaceC(ixO^S, 2)-block%surfaceC(h2x^S, 2)) &
+            / block%dvolume(ixO^S)
+       if (ndir == 3) then
+          tmp(ixO^S) = tmp(ixO^S) + (wCT(ixO^S, mom(3))**2 / wCT(ixO^S, rho_)) / tan(x(ixO^S, 2))
+       end if
+       if (.not. angmomfix) then
+          tmp(ixO^S) = tmp(ixO^S) - (wCT(ixO^S, mom(2)) * wCT(ixO^S, mr_)) / wCT(ixO^S, rho_)
+       end if
+       w(ixO^S, mom(2)) = w(ixO^S, mom(2)) + qdt * tmp(ixO^S) / x(ixO^S, 1)
 
-       if(ndir==3) then
+       if (ndir == 3) then
          ! s[mphi]=-(mphi*mr/rho)/r-cot(theta)*(mtheta*mphi/rho)/r
-         if(.not. angmomfix) then
-           tmp(ixO^S)=-(wCT(ixO^S,mom(3))*wCT(ixO^S,mr_))/wCT(ixO^S,rho_)&
-                      -(wCT(ixO^S,mom(2))*wCT(ixO^S,mom(3)))/wCT(ixO^S,rho_)/tan(x(ixO^S,2))
-           w(ixO^S,mom(3))=w(ixO^S,mom(3))+qdt*tmp(ixO^S)/x(ixO^S,1)
+         if (.not. angmomfix) then
+           tmp(ixO^S) = -(wCT(ixO^S, mom(3)) * wCT(ixO^S, mr_)) / wCT(ixO^S, rho_)&
+                      - (wCT(ixO^S, mom(2)) * wCT(ixO^S, mom(3))) / wCT(ixO^S, rho_) / tan(x(ixO^S, 2))
+           w(ixO^S, mom(3)) = w(ixO^S, mom(3)) + qdt * tmp(ixO^S) / x(ixO^S, 1)
          end if
        end if
        }

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -673,19 +673,19 @@ contains
     case ("cylindrical")
        ! s[mr]=(pthermal+mphi**2/rho)/radius
        call hd_get_pthermal(wCT,x,ixI^L,ixO^L,tmp)
-       if(phi_>0) then
-         tmp(ixO^S)=tmp(ixO^S)+wCT(ixO^S,mphi_)**2/wCT(ixO^S,rho_)
-         w(ixO^S,mr_)=w(ixO^S,mr_)+qdt*tmp(ixO^S)/x(ixO^S,1)
+       if (phi_ > 0) then
+         tmp(ixO^S) = tmp(ixO^S) + wCT(ixO^S,mphi_)**2 / wCT(ixO^S,rho_)
+         w(ixO^S,mr_) = w(ixO^S,mr_) + qdt*tmp(ixO^S) / x(ixO^S,1)
          ! s[mphi]=(-mphi*mr/rho)/radius
          ! Ileyk : beware the index permutation : mphi=2 if -phi=2 (2.5D
          ! (r,theta) grids) BUT mphi=3 if -phi=3 (for 2.5D (r,z) grids)
          if(.not. angmomfix) then
-           tmp(ixO^S)=-wCT(ixO^S,mphi_)*wCT(ixO^S,mr_)/wCT(ixO^S,rho_)
-           w(ixO^S,mphi_)=w(ixO^S,mphi_)+qdt*tmp(ixO^S)/x(ixO^S,1)
+           tmp(ixO^S) = -wCT(ixO^S,mphi_) * wCT(ixO^S,mr_) / wCT(ixO^S,rho_)
+           w(ixO^S,mphi_) = w(ixO^S,mphi_) + qdt*tmp(ixO^S) / x(ixO^S,1)
          end if
        else
          ! s[mr]=2pthermal/radius
-         w(ixO^S,mr_)=w(ixO^S,mr_)+qdt*tmp(ixO^S)/x(ixO^S,1)
+         w(ixO^S,mr_) = w(ixO^S,mr_)+qdt*tmp(ixO^S)/x(ixO^S,1)
        end if
     case ("spherical")
        h1x^L=ixO^L-kr(1,^D); {^NOONED h2x^L=ixO^L-kr(2,^D);}

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -652,7 +652,7 @@ contains
   !> not ndim. Eg, they are the same in 2.5D and in 3D, for any geometry.
   !>
   !> Ileyk : to do :
-  !>     - address the source term for the dust
+  !>     - address the source term for the dust in case (typeaxial == 'spherical')
   subroutine hd_add_source_geom(qdt, ixI^L, ixO^L, wCT, w, x)
     use mod_global_parameters
     use mod_viscosity, only: visc_add_source_geom ! viscInDiv

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -663,8 +663,7 @@ contains
     ! to change and to set as a parameter in the parfile once the possibility to
     ! solve the equations in an angular momentum conserving form has been
     ! implemented (change tvdlf.t eg)
-    double precision :: tmp(ixI^S),tmp1(ixI^S)
-    double precision :: source(ixI^S)
+    double precision :: pth(ixI^S), source(ixI^S)
     integer                         :: iw,idir, h1x^L{^NOONED, h2x^L}
     integer :: mr_,mphi_ ! Polar var. names
     integer :: irho, ifluid, n_fluids = 1
@@ -707,36 +706,36 @@ contains
        mphi_ = mom(phi_)
        h1x^L=ixO^L-kr(1,^D); {^NOONED h2x^L=ixO^L-kr(2,^D);}
        ! s[mr]=((mtheta**2+mphi**2)/rho+2*p)/r
-       call hd_get_pthermal(wCT, x, ixI^L, ixO^L, tmp1)
-       tmp(ixO^S) = tmp1(ixO^S) * x(ixO^S, 1) &
+       call hd_get_pthermal(wCT, x, ixI^L, ixO^L, pth)
+       source(ixO^S) = pth(ixO^S) * x(ixO^S, 1) &
             *(block%surfaceC(ixO^S, 1) - block%surfaceC(h1x^S, 1)) &
             /block%dvolume(ixO^S)
        if (ndir > 1) then
          do idir = 2, ndir
-           tmp(ixO^S) = tmp(ixO^S) + wCT(ixO^S, mom(idir))**2 / wCT(ixO^S, rho_)
+           source(ixO^S) = source(ixO^S) + wCT(ixO^S, mom(idir))**2 / wCT(ixO^S, rho_)
          end do
        end if
-       w(ixO^S, mr_) = w(ixO^S, mr_) + qdt*tmp(ixO^S) / x(ixO^S, 1)
+       w(ixO^S, mr_) = w(ixO^S, mr_) + qdt * source(ixO^S) / x(ixO^S, 1)
 
        {^NOONED
        ! s[mtheta]=-(mr*mtheta/rho)/r+cot(theta)*(mphi**2/rho+p)/r
-       tmp(ixO^S) = tmp1(ixO^S) * x(ixO^S, 1) &
-            * (block%surfaceC(ixO^S, 2)-block%surfaceC(h2x^S, 2)) &
+       source(ixO^S) = pth(ixO^S) * x(ixO^S, 1) &
+            * (block%surfaceC(ixO^S, 2) - block%surfaceC(h2x^S, 2)) &
             / block%dvolume(ixO^S)
        if (ndir == 3) then
-          tmp(ixO^S) = tmp(ixO^S) + (wCT(ixO^S, mom(3))**2 / wCT(ixO^S, rho_)) / tan(x(ixO^S, 2))
+          source(ixO^S) = source(ixO^S) + (wCT(ixO^S, mom(3))**2 / wCT(ixO^S, rho_)) / tan(x(ixO^S, 2))
        end if
        if (.not. angmomfix) then
-          tmp(ixO^S) = tmp(ixO^S) - (wCT(ixO^S, mom(2)) * wCT(ixO^S, mr_)) / wCT(ixO^S, rho_)
+          source(ixO^S) = source(ixO^S) - (wCT(ixO^S, mom(2)) * wCT(ixO^S, mr_)) / wCT(ixO^S, rho_)
        end if
-       w(ixO^S, mom(2)) = w(ixO^S, mom(2)) + qdt * tmp(ixO^S) / x(ixO^S, 1)
+       w(ixO^S, mom(2)) = w(ixO^S, mom(2)) + qdt * source(ixO^S) / x(ixO^S, 1)
 
        if (ndir == 3) then
          ! s[mphi]=-(mphi*mr/rho)/r-cot(theta)*(mtheta*mphi/rho)/r
          if (.not. angmomfix) then
-           tmp(ixO^S) = -(wCT(ixO^S, mom(3)) * wCT(ixO^S, mr_)) / wCT(ixO^S, rho_)&
+           source(ixO^S) = -(wCT(ixO^S, mom(3)) * wCT(ixO^S, mr_)) / wCT(ixO^S, rho_)&
                       - (wCT(ixO^S, mom(2)) * wCT(ixO^S, mom(3))) / wCT(ixO^S, rho_) / tan(x(ixO^S, 2))
-           w(ixO^S, mom(3)) = w(ixO^S, mom(3)) + qdt * tmp(ixO^S) / x(ixO^S, 1)
+           w(ixO^S, mom(3)) = w(ixO^S, mom(3)) + qdt * source(ixO^S) / x(ixO^S, 1)
          end if
        end if
        }

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -674,7 +674,7 @@ contains
     case ("cylindrical")
        do ifluid = 0, n_fluids-1
           ! s[mr]=(pthermal+mphi**2/rho)/radius
-          if (ifluid .eq. 0) then
+          if (ifluid == 0) then
              ! gas
              irho  = rho_
              mr_   = mom(r_)

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -656,7 +656,7 @@ contains
   subroutine hd_add_source_geom(qdt, ixI^L, ixO^L, wCT, w, x)
     use mod_global_parameters
     use mod_viscosity, only: visc_add_source_geom ! viscInDiv
-    use mod_dust, only: dust_mom, dust_rho
+    use mod_dust, only: dust_n_species, dust_mom, dust_rho
     integer, intent(in)             :: ixI^L, ixO^L
     double precision, intent(in)    :: qdt, x(ixI^S, 1:ndim)
     double precision, intent(inout) :: wCT(ixI^S, 1:nw), w(ixI^S, 1:nw)
@@ -670,6 +670,7 @@ contains
     integer :: irho, ifluid, n_fluids = 1
     mr_=mom(1); mphi_=mom(1)-1+phi_ ! Polar var. names
 
+    if (hd_dust) n_fluids = 1 + dust_n_species
     select case (typeaxial)
     case ("cylindrical")
        do ifluid = 0, n_fluids-1
@@ -679,7 +680,7 @@ contains
              mr_   = mom(1)
              mphi_ = mom(1) - 1 + phi_
              call hd_get_pthermal(wCT, x, ixI^L, ixO^L, source)
-          else
+          else !dust
              irho  = dust_rho(ifluid)
              mr_   = dust_mom(ifluid, r_)
              mphi_ = dust_mom(ifluid, phi_)

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -668,7 +668,6 @@ contains
     integer                         :: iw,idir, h1x^L{^NOONED, h2x^L}
     integer :: mr_,mphi_ ! Polar var. names
     integer :: irho, ifluid, n_fluids = 1
-    mr_=mom(1); mphi_=mom(1)-1+phi_ ! Polar var. names
 
     if (hd_dust) n_fluids = 1 + dust_n_species
 
@@ -676,12 +675,14 @@ contains
     case ("cylindrical")
        do ifluid = 0, n_fluids-1
           ! s[mr]=(pthermal+mphi**2/rho)/radius
-          if (ifluid .eq. 0) then !gas
+          if (ifluid .eq. 0) then
+             ! gas
              irho  = rho_
              mr_   = mom(r_)
              mphi_ = mom(phi_)
              call hd_get_pthermal(wCT, x, ixI^L, ixO^L, source)
-          else !dust
+          else
+             ! dust : no pressure
              irho  = dust_rho(ifluid)
              mr_   = dust_mom(ifluid, r_)
              mphi_ = dust_mom(ifluid, phi_)
@@ -701,6 +702,9 @@ contains
           end if
        end do
     case ("spherical")
+       ! Clement : case (hd_dust == .true.) not implemented yet
+       mr_   = mom(r_)
+       mphi_ = mom(phi_)
        h1x^L=ixO^L-kr(1,^D); {^NOONED h2x^L=ixO^L-kr(2,^D);}
        ! s[mr]=((mtheta**2+mphi**2)/rho+2*p)/r
        call hd_get_pthermal(wCT,x,ixI^L,ixO^L,tmp1)

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -705,7 +705,9 @@ contains
           end if
        end do
     case ("spherical")
-       ! Clement : case (hd_dust == .true.) not implemented yet
+       if (hd_dust) then
+          call mpistop("Dust geom source terms not implemented yet with spherical geometries")
+       end if
        mr_   = mom(r_)
        mphi_ = mom(phi_)
        h1x^L=ixO^L-kr(1,^D); {^NOONED h2x^L=ixO^L-kr(2,^D);}

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -675,18 +675,18 @@ contains
        ! s[mr]=(pthermal+mphi**2/rho)/radius
        call hd_get_pthermal(wCT, x, ixI^L, ixO^L, source)
        if (phi_ > 0) then
-         source(ixO^S) = source(ixO^S) + wCT(ixO^S,mphi_)**2 / wCT(ixO^S,rho_)
-         w(ixO^S, mr_) = w(ixO^S,mr_) + qdt * source(ixO^S) / x(ixO^S,1)
+         source(ixO^S) = source(ixO^S) + wCT(ixO^S, mphi_)**2 / wCT(ixO^S, rho_)
+         w(ixO^S, mr_) = w(ixO^S, mr_) + qdt * source(ixO^S) / x(ixO^S, 1)
          ! s[mphi]=(-mphi*mr/rho)/radius
          ! Ileyk : beware the index permutation : mphi=2 if -phi=2 (2.5D
          ! (r,theta) grids) BUT mphi=3 if -phi=3 (for 2.5D (r,z) grids)
          if(.not. angmomfix) then
-           source(ixO^S) = -wCT(ixO^S,mphi_) * wCT(ixO^S,mr_) / wCT(ixO^S,rho_)
-           w(ixO^S,mphi_) = w(ixO^S,mphi_) + qdt * source(ixO^S) / x(ixO^S,1)
+           source(ixO^S) = -wCT(ixO^S, mphi_) * wCT(ixO^S, mr_) / wCT(ixO^S, rho_)
+           w(ixO^S, mphi_) = w(ixO^S, mphi_) + qdt * source(ixO^S) / x(ixO^S, 1)
          end if
        else
          ! s[mr]=2pthermal/radius
-         w(ixO^S,mr_) = w(ixO^S,mr_) + qdt * source(ixO^S) / x(ixO^S,1)
+         w(ixO^S,mr_) = w(ixO^S,mr_) + qdt * source(ixO^S) / x(ixO^S, 1)
        end if
     case ("spherical")
        h1x^L=ixO^L-kr(1,^D); {^NOONED h2x^L=ixO^L-kr(2,^D);}

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -671,14 +671,15 @@ contains
     mr_=mom(1); mphi_=mom(1)-1+phi_ ! Polar var. names
 
     if (hd_dust) n_fluids = 1 + dust_n_species
+
     select case (typeaxial)
     case ("cylindrical")
        do ifluid = 0, n_fluids-1
           ! s[mr]=(pthermal+mphi**2/rho)/radius
           if (ifluid .eq. 0) then !gas
              irho  = rho_
-             mr_   = mom(1)
-             mphi_ = mom(1) - 1 + phi_
+             mr_   = mom(r_)
+             mphi_ = mom(phi_)
              call hd_get_pthermal(wCT, x, ixI^L, ixO^L, source)
           else !dust
              irho  = dust_rho(ifluid)
@@ -690,8 +691,6 @@ contains
              source(ixO^S) = source(ixO^S) + wCT(ixO^S, mphi_)**2 / wCT(ixO^S, irho)
              w(ixO^S, mr_) = w(ixO^S, mr_) + qdt * source(ixO^S) / x(ixO^S, 1)
              ! s[mphi]=(-mphi*mr/rho)/radius
-             ! Ileyk : beware the index permutation : mphi=2 if -phi=2 (2.5D
-             ! (r,theta) grids) BUT mphi=3 if -phi=3 (for 2.5D (r,z) grids)
              if(.not. angmomfix) then
                 source(ixO^S) = -wCT(ixO^S, mphi_) * wCT(ixO^S, mr_) / wCT(ixO^S, irho)
                 w(ixO^S, mphi_) = w(ixO^S, mphi_) + qdt * source(ixO^S) / x(ixO^S, 1)

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -664,6 +664,7 @@ contains
     ! solve the equations in an angular momentum conserving form has been
     ! implemented (change tvdlf.t eg)
     double precision :: tmp(ixI^S),tmp1(ixI^S)
+    double precision :: source(ixI^S)
     integer                         :: iw,idir, h1x^L{^NOONED, h2x^L}
     integer :: mr_,mphi_ ! Polar var. names
 
@@ -672,20 +673,20 @@ contains
     select case (typeaxial)
     case ("cylindrical")
        ! s[mr]=(pthermal+mphi**2/rho)/radius
-       call hd_get_pthermal(wCT,x,ixI^L,ixO^L,tmp)
+       call hd_get_pthermal(wCT, x, ixI^L, ixO^L, source)
        if (phi_ > 0) then
-         tmp(ixO^S) = tmp(ixO^S) + wCT(ixO^S,mphi_)**2 / wCT(ixO^S,rho_)
-         w(ixO^S,mr_) = w(ixO^S,mr_) + qdt*tmp(ixO^S) / x(ixO^S,1)
+         source(ixO^S) = source(ixO^S) + wCT(ixO^S,mphi_)**2 / wCT(ixO^S,rho_)
+         w(ixO^S, mr_) = w(ixO^S,mr_) + qdt * source(ixO^S) / x(ixO^S,1)
          ! s[mphi]=(-mphi*mr/rho)/radius
          ! Ileyk : beware the index permutation : mphi=2 if -phi=2 (2.5D
          ! (r,theta) grids) BUT mphi=3 if -phi=3 (for 2.5D (r,z) grids)
          if(.not. angmomfix) then
-           tmp(ixO^S) = -wCT(ixO^S,mphi_) * wCT(ixO^S,mr_) / wCT(ixO^S,rho_)
-           w(ixO^S,mphi_) = w(ixO^S,mphi_) + qdt*tmp(ixO^S) / x(ixO^S,1)
+           source(ixO^S) = -wCT(ixO^S,mphi_) * wCT(ixO^S,mr_) / wCT(ixO^S,rho_)
+           w(ixO^S,mphi_) = w(ixO^S,mphi_) + qdt * source(ixO^S) / x(ixO^S,1)
          end if
        else
          ! s[mr]=2pthermal/radius
-         w(ixO^S,mr_) = w(ixO^S,mr_)+qdt*tmp(ixO^S)/x(ixO^S,1)
+         w(ixO^S,mr_) = w(ixO^S,mr_) + qdt * source(ixO^S) / x(ixO^S,1)
        end if
     case ("spherical")
        h1x^L=ixO^L-kr(1,^D); {^NOONED h2x^L=ixO^L-kr(2,^D);}

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -666,9 +666,13 @@ contains
     double precision :: pth(ixI^S), source(ixI^S)
     integer                         :: iw,idir, h1x^L{^NOONED, h2x^L}
     integer :: mr_,mphi_ ! Polar var. names
-    integer :: irho, ifluid, n_fluids = 1
+    integer :: irho, ifluid, n_fluids
 
-    if (hd_dust) n_fluids = 1 + dust_n_species
+    if (hd_dust) then
+       n_fluids = 1 + dust_n_species
+    else
+       n_fluids = 1
+    end if
 
     select case (typeaxial)
     case ("cylindrical")

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -689,15 +689,15 @@ contains
           end if
           if (phi_ > 0) then
              source(ixO^S) = source(ixO^S) + wCT(ixO^S, mphi_)**2 / wCT(ixO^S, irho)
-             w(ixO^S, mr_) = w(ixO^S, mr_) + qdt * source(ixO^S) / x(ixO^S, 1)
+             w(ixO^S, mr_) = w(ixO^S, mr_) + qdt * source(ixO^S) / x(ixO^S, r_)
              ! s[mphi]=(-mphi*mr/rho)/radius
              if(.not. angmomfix) then
                 source(ixO^S) = -wCT(ixO^S, mphi_) * wCT(ixO^S, mr_) / wCT(ixO^S, irho)
-                w(ixO^S, mphi_) = w(ixO^S, mphi_) + qdt * source(ixO^S) / x(ixO^S, 1)
+                w(ixO^S, mphi_) = w(ixO^S, mphi_) + qdt * source(ixO^S) / x(ixO^S, r_)
              end if
           else
              ! s[mr]=2pthermal/radius
-             w(ixO^S,mr_) = w(ixO^S,mr_) + qdt * source(ixO^S) / x(ixO^S, 1)
+             w(ixO^S, mr_) = w(ixO^S, mr_) + qdt * source(ixO^S) / x(ixO^S, r_)
           end if
        end do
     case ("spherical")


### PR DESCRIPTION
* implement geom source terms for dust in case `typeaxial == "cylindrical"`
* improve readability (explicit variable names + spacing + use magic variables `r_`)

notes:
-------
- I'll come back to this when I start 3d simulations, where I'll need `typeaxial == "spherical"`
- Although all existing hd tests pass, dust's behavior *is* changed by this update in polar geometries, hopefully in a more physical way.