### PR TITLE
allow strictly null hd_adiab

### DIFF
--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -262,7 +262,7 @@ contains
 
     if (.not. hd_energy) then
        if (hd_gamma <= 0.0d0) call mpistop ("Error: hd_gamma <= 0")
-       if (hd_adiab <= 0.0d0) call mpistop ("Error: hd_adiab <= 0")
+       if (hd_adiab < 0.0d0) call mpistop  ("Error: hd_adiab < 0")
        small_pressure= hd_adiab*small_density**hd_gamma
     else
        if (hd_gamma <= 0.0d0 .or. hd_gamma == 1.0d0) &


### PR DESCRIPTION
Although unphysical, I find this very useful for testing of `mod_dust.t`'s physics.
With `hd_adiab = 0` and  `hd_energy = .false.`, gas behaves like dust because there's no pressure.

There may be good reasons to keep forbiding this in the general release of the code, that I'm unaware of, which is why I'm asking for review.