### PR TITLE
Dust to zero

### DIFF
--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -656,7 +656,7 @@ contains
   subroutine hd_add_source_geom(qdt, ixI^L, ixO^L, wCT, w, x)
     use mod_global_parameters
     use mod_viscosity, only: visc_add_source_geom ! viscInDiv
-    use mod_dust, only: dust_n_species, dust_mom, dust_rho
+    use mod_dust, only: dust_n_species, dust_mom, dust_rho, dust_small_to_zero, set_dusttozero
     integer, intent(in)             :: ixI^L, ixO^L
     double precision, intent(in)    :: qdt, x(ixI^S, 1:ndim)
     double precision, intent(inout) :: wCT(ixI^S, 1:nw), w(ixI^S, 1:nw)
@@ -747,6 +747,10 @@ contains
        }
     end select
 
+    if (hd_dust .and. dust_small_to_zero) then
+       call set_dusttozero(qdt, ixI^L, ixO^L,  wCT,  w, x)
+    end if
+
     if (hd_viscosity) call visc_add_source_geom(qdt,ixI^L,ixO^L,wCT,w,x)
 
   end subroutine hd_add_source_geom
@@ -759,6 +763,7 @@ contains
     use mod_viscosity, only: viscosity_add_source
     use mod_usr_methods, only: usr_gravity
     use mod_gravity, only: gravity_add_source, grav_split
+    use mod_dust, only: dust_small_to_zero, set_dusttozero
 
     integer, intent(in)             :: ixI^L, ixO^L
     double precision, intent(in)    :: qdt
@@ -798,6 +803,9 @@ contains
                     + qdt * gravity_field(ixO^S, idim) * wCT(ixO^S, dust_rho(idust))
             end do
          end do
+         if (dust_small_to_zero) then
+            call set_dusttozero(qdt, ixI^L, ixO^L,  wCT,  w, x)
+         end if
       end if
     end if
 

--- a/src/physics/mod_dust.t
+++ b/src/physics/mod_dust.t
@@ -37,7 +37,7 @@ module mod_dust
   double precision :: dust_stellar_luminosity = -1.0d0
 
   !> Set small dust densities to zero to avoid numerical problems
-  logical :: dust_small_to_zero = .false.
+  logical, public, protected :: dust_small_to_zero = .false.
 
   !> Minimum dust density
   double precision :: dust_min_rho = -1.0d0
@@ -68,6 +68,7 @@ module mod_dust
   public :: dust_to_conserved
   public :: dust_to_primitive
   public :: dust_check_params
+  public :: set_dusttozero
 
 contains
 

--- a/src/physics/mod_dust.t
+++ b/src/physics/mod_dust.t
@@ -40,7 +40,7 @@ module mod_dust
   logical, public, protected :: dust_small_to_zero = .false.
 
   !> Minimum dust density
-  double precision :: dust_min_rho = -1.0d0
+  double precision, public, protected :: dust_min_rho = -1.0d0
 
   !> TODO: 1. Introduce this generically in advance, 2: document
   logical :: dust_source_split = .false.


### PR DESCRIPTION
propagate the behavior of `dust_add_source` to new source terms:
- only apply sources where density is above threshold
- set density and momentum to proper 0 where density has gone bellow said threshold after applying sources, using the logical `dust_small_to_zero` activating `set_dusttozero`. This logical and the corresponding routine were made public (and protected) to allow their usage by module `mod_hd_phys.t`.