### PR TITLE
Dust method stokes

### DIFF
--- a/src/physics/mod_dust.t
+++ b/src/physics/mod_dust.t
@@ -149,14 +149,20 @@ contains
        end if
     end if
 
-    if (any(dust_size < 0.0d0) .and. dust_method /= 'Stokes' .and. dust_method /= 'none') &
-         call mpistop("Dust error: any(dust_size < 0) or not set")
-
-    if (any(dust_density < 0.0d0) .and. dust_method /= 'Stokes' .and. dust_method /= 'none') &
-         call mpistop("Dust error: any(dust_density < 0) or not set")
-
-    if (any(dust_stokes < 0.d0) .and. dust_method == 'Stokes') &
+    if (dust_method == 'none') then
+       if (any(dust_stokes < 0.d0) &
+            .and. (any(dust_size < 0.0d0) .or. any(dust_density < 0.0d0))) then
+          call mpistop("With dust_method=='none', you must set either"// &
+               "(dust_density, dust_size) or dust_stokes")
+       end if
+    else if (dust_method == 'Stokes' .and. any(dust_stokes < 0.d0)) then
          call mpistop("Dust error: any(dust_stokes < 0) or not set")
+    else
+       if (any(dust_size < 0.0d0)) &
+            call mpistop("Dust error: any(dust_size < 0) or not set")
+       if (any(dust_density < 0.0d0)) &
+            call mpistop("Dust error: any(dust_density < 0) or not set")
+    end if
   end subroutine dust_check_params
 
   subroutine dust_to_conserved(ixI^L, ixO^L, w, x)

--- a/src/physics/mod_dust.t
+++ b/src/physics/mod_dust.t
@@ -135,23 +135,24 @@ contains
   end subroutine dust_read_params
 
   subroutine dust_check_params()
-    if (gas_mu <= 0.0d0) call mpistop ("Dust error: gas_mu (molecular weight)"//&
-         "negative or not set")
-
-    if (dust_temperature_type == "constant") then
-       if (dust_temperature < 0.0d0) then
-          call mpistop("Dust error: dust_temperature < 0 or not set")
-       end if
-    else if (dust_temperature_type == "stellar") then
-       if (dust_stellar_luminosity < 0.0d0) then
-          call mpistop("Dust error: dust_stellar_luminosity < 0 or not set")
+    if (gas_mu <= 0.0d0 .and. (dust_method == 'Kwok' .or. dust_method == 'sticking')) &
+         call mpistop ("Dust error: gas_mu (molecular weight) negative or not set")
+    if (dust_method == 'sticking') then
+       if (dust_temperature_type == "constant") then
+          if (dust_temperature < 0.0d0) then
+             call mpistop("Dust error: dust_temperature < 0 or not set")
+          end if
+       else if (dust_temperature_type == "stellar") then
+          if (dust_stellar_luminosity < 0.0d0) then
+             call mpistop("Dust error: dust_stellar_luminosity < 0 or not set")
+          end if
        end if
     end if
 
-    if (any(dust_size < 0.0d0) .and. dust_method /= 'Stokes') &
+    if (any(dust_size < 0.0d0) .and. dust_method /= 'Stokes' .and. dust_method /= 'none') &
          call mpistop("Dust error: any(dust_size < 0) or not set")
 
-    if (any(dust_density < 0.0d0) .and. dust_method /= 'Stokes') &
+    if (any(dust_density < 0.0d0) .and. dust_method /= 'Stokes' .and. dust_method /= 'none') &
          call mpistop("Dust error: any(dust_density < 0) or not set")
 
     if (any(dust_stokes < 0.d0) .and. dust_method == 'Stokes') &

--- a/src/physics/mod_dust.t
+++ b/src/physics/mod_dust.t
@@ -51,7 +51,7 @@ module mod_dust
   !> This can be turned off for testing purposes
   logical :: dust_backreaction = .true.
 
-  !> What type of dust drag force to use. Can be 'Kwok', 'sticking', 'linear',or 'none'.
+  !> What type of dust drag force to use. Can be 'Kwok', 'sticking', 'linear', 'Stokes' or 'none'.
   character(len=std_len) :: dust_method = 'Kwok'
 
   !> Can be 'graphite' or 'silicate', affects the dust temperature
@@ -148,13 +148,13 @@ contains
        end if
     end if
 
-    if (any(dust_size < 0.0d0) & dust_method \= 'Stokes') &
+    if (any(dust_size < 0.0d0) .and. dust_method /= 'Stokes') &
          call mpistop("Dust error: any(dust_size < 0) or not set")
 
-    if (any(dust_density < 0.0d0) & dust_method \= 'Stokes') &
+    if (any(dust_density < 0.0d0) .and. dust_method /= 'Stokes') &
          call mpistop("Dust error: any(dust_density < 0) or not set")
 
-    if (any(dust_stokes < 0.d0) & dust_method = 'Stokes') &
+    if (any(dust_stokes < 0.d0) .and. dust_method == 'Stokes') &
          call mpistop("Dust error: any(dust_stokes < 0) or not set")
   end subroutine dust_check_params
 
@@ -640,7 +640,7 @@ contains
 
       do n = 1, dust_n_species
         where(w(ixO^S, dust_rho(n))>dust_min_rho)
-          tstop(ixO^S)  = dust_stoker(n)*w(ixO^S, gas_rho_)/ &
+          tstop(ixO^S)  = dust_stokes(n)*w(ixO^S, gas_rho_)/ &
                (w(ixO^S, dust_rho(n)) + w(ixO^S, gas_rho_))
         else where
           tstop(ixO^S) = bigdouble


### PR DESCRIPTION
We add a new paradigm for setting up dust populations, with an associated `dust_method` "Stokes"
Instead of setting the grain density and their size, we allow the user to set directly a stokes number (dimensionless stopping time).