### PR TITLE
CI migration to GitHub Actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,46 @@
+name: code-coverage
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  CC: /usr/bin/gcc-9
+  FC: /usr/bin/gfortran-9
+  AMRVAC_DIR: ${GITHUB_WORKSPACE}
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          sudo apt-get install openmpi-bin libopenmpi-dev
+          mpirun --version
+          gfortran-9 --version
+          pip install gcovr
+      - name: Compile amrvac
+        run: |
+          cd lib
+          make -j 2 ARCH=coverage
+      - name: Run tests
+        run: |
+          cd tests
+          make -j 2 ARCH=coverage
+      - name: Generate coverage report
+        run: |
+          mkdir coverage
+          cd lib
+          gcovr -r . --print-summary --html --html-details --output ../coverage/coverage.html
+      - name: Upload report
+        uses: actions/upload-artifact@v1
+        if: success()
+        with:
+          name: coverage_report
+          path: coverage/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,125 @@
+name: tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CC: /usr/bin/gcc-9
+  FC: /usr/bin/gfortran-9
+  AMRVAC_DIR: ${GITHUB_WORKSPACE}
+
+jobs:
+  rho:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          sudo apt-get install openmpi-bin libopenmpi-dev
+          gfortran-9 --version
+          mpirun --version
+      - name: check code dependencies
+        run: |
+          cd src
+          sh update_dependencies.sh --verbose || exit 1
+      - name: compile
+        run: |
+          cd lib
+          make clean
+          make -j 2 || exit 1
+      - name: run tests
+        run: |
+          cd tests
+          bash test_runner.sh rho
+  hd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          sudo apt-get install openmpi-bin libopenmpi-dev
+          gfortran-9 --version
+          mpirun --version
+      - name: check code dependencies
+        run: |
+          cd src
+          sh update_dependencies.sh --verbose || exit 1
+      - name: compile
+        run: |
+          cd lib
+          make clean
+          make -j 2 || exit 1
+      - name: run tests
+        run: |
+          cd tests
+          bash test_runner.sh hd
+          
+  mhd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          sudo apt-get install openmpi-bin libopenmpi-dev
+          gfortran-9 --version
+          mpirun --version
+      - name: check code dependencies
+        run: |
+          cd src
+          sh update_dependencies.sh --verbose || exit 1
+      - name: compile
+        run: |
+          cd lib
+          make clean
+          make -j 2 || exit 1
+      - name: run tests
+        run: |
+          cd tests
+          bash test_runner.sh mhd
+  rd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          sudo apt-get install openmpi-bin libopenmpi-dev
+          gfortran-9 --version
+          mpirun --version
+      - name: check code dependencies
+        run: |
+          cd src
+          sh update_dependencies.sh --verbose || exit 1
+      - name: compile
+        run: |
+          cd lib
+          make clean
+          make -j 2 || exit 1
+      - name: run tests
+        run: |
+          cd tests
+          bash test_runner.sh rd
+  mg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          sudo apt-get install openmpi-bin libopenmpi-dev
+          gfortran-9 --version
+          mpirun --version
+      - name: check code dependencies
+        run: |
+          cd src
+          sh update_dependencies.sh --verbose || exit 1
+      - name: compile
+        run: |
+          cd lib
+          make clean
+          make -j 2 || exit 1
+      - name: run tests
+        run: |
+          cd tests
+          bash test_runner.sh mg

--- a/arch/coverage.defs
+++ b/arch/coverage.defs
@@ -1,0 +1,4 @@
+F90 = mpif90
+FFLAGS = -c
+F90FLAGS = -ffree-form --coverage -O2
+LINK = $(F90) $(F90FLAGS)

--- a/tests/test_runner.sh
+++ b/tests/test_runner.sh
@@ -1,11 +1,11 @@
-# this is part of the travis ci/cd pipeline
+# this is part of the continuous integration pipeline
 # call syntax:
-# bash test_runner.sh hd
+# bash test_runner.sh <name>
 #
 # Run tests in $1 and check if any fails
 # return appropriate exit code (0 if and only if all tests pass)
 
-make -s $1 | tee $1.out; test ${PIPESTATUS[0]} -eq 0
+make -j 2 -s $1 | tee $1.out; test ${PIPESTATUS[0]} -eq 0
 cond1=$? # first condition: build correctly with make
 
 if [ $cond1 != 0 ] ; then


### PR DESCRIPTION
This PR migrates the automated tests from Travis to GitHub Actions.
Everything is integrated into GitHub now, accessible through the "Actions" tab above. General overview is much clearer, with separate test tabs for every module.
For every commit we now have 5 checks:
- tests/rho
- tests/hd
- tests/mhd
- tests/rd
- tests/mg

so it is immediately clear which ones are failing.

Also added the option to generate a coverage report, but since this takes quite a while this has to be triggered manually if desired. This can be done by going to the Actions tab => code-coverage => Run workflow (select a branch). 
Running all tests with code coverage enabled takes about 3-4 hours, after completion the final report can be downloaded as a .zip file through the Actions tab => click on completed workflow => artifacts.