### PR TITLE
update cak force and rotating frame

### DIFF
--- a/doc/cakforce.md
+++ b/doc/cakforce.md
@@ -40,15 +40,16 @@ With this formula all components of the force can be computed: \f$ \mathbf{g}_\m
 Finally, note that contrary to the RHD physics module of MPI-AMRVAC, the radiation force prescription presented here is a **reduced** dynamical picture. Indeed, we do not solve for the detailed radiation-energy exchange that is done via the flux-limited diffusion in the RHD module. This is justified since for the typical stellar conditions where the CAK force prescription applies (OB-star atmospheres), such detailed radiation-energy exchanges between the radiation field and gas are rather minor and instead the radiation dynamically couples to the gas only without considering the radiation energy budget.
 
 # Practical use
-In order to add the CAK force to a line-driven stellar wind simulation, the user has to adjust the .par file as indicated in this section. A 1D and 2.5D example test problem of this module is also provided in the HD tests folder.
+In order to add the CAK force to a line-driven stellar wind simulation, the user has to adjust the .par file as indicated in this section.
 
 ## Activating the module
-Depending whether the setup is in (M)HD, the the force needs to be activated in the physics-dependent namelist. This means that for a (M)HD simulation one adds in the `&(m)hd_list` the following:
+Depending whether the setup is in (M)HD, the the force needs to be activated in the physics-dependent namelist. This means that for a HD simulation one adds in the `&hd_list` the following:
 ```
-&(m)hd_list
-  (m)hd_cak_force = .true.
+&hd_list
+  hd_cak_force = .true.
 /
 ```
+and a similar procedure applies for the `&mhd_list` with `mhd_cak_force`.
 
 ## Customizing the setup
 Additionally, specific parameters can be set in the `&cak_list` for the source term physics treatment. In the following table, the available parameters are briefly described with their possible values. If some values are not set, they are default to a 1-D CAK force prescription for a proto-typical Galactic O-supergiant.
@@ -65,6 +66,12 @@ nthetaray | integer | 6 | If `cak_vector_force=T`, amount of radiation ray point
 nphiray | integer | 6 | If `cak_vector_force=T`, amount of radiation ray points used to describe the radiation angle \f$\Phi\f$.
 fix_vector_force_1d | logical | F | If true, the CAK vector line force will only have a non-zero radial component.
 cak_split |  logical | F | To add the source term in a split or unsplit (default) fashion.
+
+## Test problems
+Two test problems are provided in the HD tests folder that can be configured in several wats to illustrate the above physics, see `CAKwind_spherical_1D` and `CAKwind_spherical_2.5D`. Functionalities included are:
+- 1D and 2.5D spherical isothermal or adiabatic wind models.
+- Rotating frame of reference for 2.5D wind.
+- Radial line force or vector line force with one or more of the previous listed combinations.
 
 # Numerics and implementation
 
@@ -83,7 +90,7 @@ This subroutine computes the force normalisation in dimensionless units. **It ha
 *cak_add_source:*
 The subroutine cak_add_source is called at each timestep to add the CAK line force together with the radial Thomson (continuum) force. Depending on the chosen option (`cak_1d_force` or `cak_vector_force`) either the original 1-D CAK line force or the full CAK vector force is computed. The forces are all computed in dimensionless units.
 
-In case there is adiabatic (M)HD, the forces will also be added to the energy equation. To mimic stellar heating there is a floor temperature set (being the stellar surface temperature) to the wind. This also fixes the sometimes possible occurence of negative thermal pressures in parts of the hypersonic wind outflow. However, if this happens the code will still crash inside phys_get_pthermal, that is called to compute the floor temperature.To avoid a code crash set `check_small_values=.false.` in the method_list and the floor temperature will fix any misbehaving cells instead. 
+In case there is adiabatic (M)HD, the forces will also be added to the energy equation. To mimic stellar heating there is a floor temperature set (being the stellar surface temperature) to the wind. This also fixes the sometimes possible occurrence of negative thermal pressures in parts of the hypersonic wind outflow.
 
 *cak_get_dt:*
 Since an additional force is introduced to the (M)HD system, we also check for possible time step constraints in every coordinate direction. When the 1-D CAK force is used this only applies to the radial direction again, when the vector CAK force is used then it depends on how many dimensions the problem uses to determine possible additional time step limitations.

--- a/doc/cakforce.md
+++ b/doc/cakforce.md
@@ -15,7 +15,7 @@ It should be noted that we do not follow the original CAK parametrisation (\f$ \
 \f[
 \mathbf{g}_\mathrm{r} = g_\mathrm{cont} \mathbf{e}_r + g_\mathrm{line}  \mathbf{e}_r = g_\mathrm{e}\,\mathbf{e}_r + f_\mathrm{d} g_\mathrm{line} \mathbf{e}_r
 \f]
-where \f$ g_\mathrm{e} = \kappa_\mathrm{e}L_\star/(4\pi r^2 c) \f$ is the (continuum) radiation acceleration due to Thomson scattering on free electrons with opacity \f$ \kappa_\mathrm{e}=0.34 \, \mathrm{cm}^2/g \f$. The radiation line force expression can take several forms depending on the physics included (see below). The classical radially streaming CAK expression for the force coming from a point star obeys
+where \f$ g_\mathrm{e} = \kappa_\mathrm{e}L_\star/(4\pi r^2 c) \f$ is the (continuum) radiation acceleration due to Thomson scattering on free electrons with opacity \f$ \kappa_\mathrm{e}=0.34 \f$ cm\f$^2\f$/g. The radiation line force expression can take several forms depending on the physics included (see below). The classical radially streaming CAK expression for the force coming from a point star obeys
 \f[
 g_\mathrm{line} = \frac{\bar{Q}^{1-\alpha}}{(1-\alpha)} \frac{g_\mathrm{e}}{t_r^\alpha}
 \f]
@@ -55,14 +55,14 @@ Additionally, specific parameters can be set in the `&cak_list` for the source t
 
 name | type | default | description
 ---|---|---|---
-cak_alpha | double | 0.65 | Power-law index of the CAK line-ensemble distribution function. Allowed values are in the range $\alpha\in [0,1[$.  
+cak_alpha | double | 0.65 | Power-law index of the CAK line-ensemble distribution function. Allowed values are in the range \f$\alpha\in [0,1[\f$.
 gayley_qbar | double | 2000 | Gayley (1995) ensemble-integrated line-strength of the line-ensemble distribution function. Number should be bigger than zero.
 gayley_q0 | double | 2000 | Gayley (1995) line-strength cut-off for the line-ensemble distribution function. Extension to the original CAK formulation to avoid an inifinite line force in the optically thin limit. Number should be bigger than zero.
-cak_1d_force | logical | F | If true, activate the original CAK 1-D (radial) line force prescription as source term to the (M)HD equations. Hence, computes $g_{\mathrm{line},r}$. 
+cak_1d_force | logical | F | If true, activate the original CAK 1-D (radial) line force prescription as source term to the (M)HD equations. Hence, computes \f$g_{\mathrm{line},r}\f$.
 cak_1d_opt | integer | 1 | Switch that allows to select different CAK 1-D force prescriptions. When cak_1d_opt=0 we follow the original CAK radially streaming limit (point star). When cak_1d_opt=1 the 1-D radially streaming force gets adjusted with the finite disc factor to take into account the finite extent of the star. When cak_1d_opt=2 the 1-D radially streaming force is corrected with the finite disc factor and with the line-strength cut-off.
-cak_vector_force | logical | F | If true, activate the CAK line force with components computed in all coordinate directions (radial, polar, azimuthal). Hence, computes $g_{\mathrm{line},r}$, $g_{\mathrm{line},\theta}$, and $g_{\mathrm{line},\phi}$. 
-nthetaray | integer | 6 | If `cak_vector_force=T`, amount of radiation ray points used to describe the radiation angle $\varTheta$.
-nphiray | integer | 6 | If `cak_vector_force=T`, amount of radiation ray points used to describe the radiation angle $\varPhi$.
+cak_vector_force | logical | F | If true, activate the CAK line force with components computed in all coordinate directions (radial, polar, azimuthal). Hence, computes \f$g_{\mathrm{line},r}\f$, \f$g_{\mathrm{line},\theta}\f$, and \f$g_{\mathrm{line},\phi}\f$.
+nthetaray | integer | 6 | If `cak_vector_force=T`, amount of radiation ray points used to describe the radiation angle \f$\Theta\f$.
+nphiray | integer | 6 | If `cak_vector_force=T`, amount of radiation ray points used to describe the radiation angle \f$\Phi\f$.
 fix_vector_force_1d | logical | F | If true, the CAK vector line force will only have a non-zero radial component.
 cak_split |  logical | F | To add the source term in a split or unsplit (default) fashion.
 
@@ -109,7 +109,7 @@ This routine computes a second-order spatially accurate gradient in a certain co
 If a uniform grid is used, the formulae will collapse to a second-order spatially accurate gradient expression for uniform grids.
 
 *rays_init:*
-Initialisation routine for the radiation rays when the `cak_vector_force` is applied. It distributes a preselected amount of rays with radiation angles $(\varTheta, \varPhi)$ on the (projected) stellar disc. Additionally, it assigns weights to the rays in theor contribution to the radiation line force. For convenience the radiation polar angle points are recast to a formulation in terms of impact parameter points. Both the ray points and weights are set by a Gauss-Legendre quadrature.
+Initialisation routine for the radiation rays when the `cak_vector_force` is applied. It distributes a preselected amount of rays with radiation angles (\f$\Theta\f$, \f$\Phi\f$)$ on the (projected) stellar disc. Additionally, it assigns weights to the rays in the contribution to the radiation line force. For convenience the radiation polar angle points are recast to a formulation in terms of impact parameter points. Both the ray points and weights are set by a Gauss-Legendre quadrature.
 This routine is called once in the *cak_init* routine when `cak_vector_force=T`.
 
 *gauss_legendre_quadrature:*

--- a/doc/contents.md
+++ b/doc/contents.md
@@ -49,6 +49,7 @@ the data structures for the block-tree AMR.
 * [Advection-Reaction-diffusion equations](advection_reaction_diffusion.md) Using the advection-reaction-diffusion module.
 * [Two-fluid equations](twofluid.md) Getting started with the two-fluid module.
 * [CAK radiation force](cakforce.md) Getting started with the CAK force for line-driven wind outflows.
+* [Rotating frame](rotatingframe.md) Solve governing equations in a rotating frame of reference.
 * [Adding a new physics module](addmodule.md) Description of how to add your own physics module.
 
 # Source Code {#source_code}

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -9,7 +9,7 @@ The documentation of MPI-AMRVAC is generated using
 is automatically updated. You can also generate 
 documentation locally if you have a recent version of Doxygen installed. The
 latest binaries can be downloaded
-[here](http://www.stack.nl/~dimitri/doxygen/download.html).
+[here](https://doxygen.nl/download.html).
 
 To locally generate the documentation, execute
 
@@ -23,7 +23,7 @@ in the documentation folder (`doc`). You can then open the documentation in
 # How to write documentation {#doc-howto}
 
 Below some of the Doxygen basics are described, but for more information see the
-online [manual](http://www.stack.nl/~dimitri/doxygen/manual/index.html). Having
+online [manual](https://www.doxygen.nl/manual/index.html). Having
 a quick look at the documentation already present in MPI-AMRVAC (both in the
 source code and in the `doc` folder) will also help get you started.
 
@@ -80,7 +80,7 @@ Besides documenting your source code, you can also include other information
 using special commands, preceded by a backslash (\). Examples are: **todo** to
 list TODO items, **test** to describe test cases and **page** to create a
 separate documentation page. The full list of commands is available
-[here](http://www.stack.nl/~dimitri/doxygen/manual/commands.html).
+[here](https://www.doxygen.nl/manual/commands.html).
 
 ## Documentation in markdown files {#doc-md}
 

--- a/doc/rotatingframe.md
+++ b/doc/rotatingframe.md
@@ -1,0 +1,64 @@
+# Rotating frame for HD/MHD/RHD
+
+An overview of how to activate the rotating frame module. This module works for cylindrical and spherical problems in 1-D, 2-D, and 3-D.
+
+# Physics
+
+For some problems it may be desirable to let the coordinate system rotate with a certain rate and perform computations in a rotating frame of reference. For example, one can anchor then the coordinate system to the object under study to yield simpler boundary conditions. This method will, however, lead to the introduction of fictitious or "pseudo" forces in the governing equations of the system. Particularly, the Coriolis force and the centrifugal force need to be taken into account.
+
+When active, the rotating_frame.t module adds these fictitious sources to the momentum and energy equations. At all times the rotation axis of the frame is assumed to point along the \f$ z \f$-axis of a Cartesian coordinate system. Similarly the rotating frame rotates at a **uniform** angular frequency \f$ \omega_0 \f$, meaning no fictitious Euler force can develop.
+
+**NOTE**: The user should be aware that the fictitious forces are **not** added in an angular momentum conserving fashion. The latter means that the azimuthal component of the Coriolis force is incorporated directly into the azimuthal flux computation within the conservative equations. Such angular momentum conserving formulation may be important for some applications, see for example [Kley (1998)](https://ui.adsabs.harvard.edu/abs/1998A%26A...338L..37K/abstract). The present implementation in MPI-AMRVAC adds all fictitious force components displayed below as source terms to the conservative equations.
+
+## Cylindrical coordinates
+
+The extra fictitious sources added to the momentum equations:
+\f{eqnarray*}{
+ S_{\rho v_r}    &=& 2\omega_0 v_\phi + \omega_0**2 r, \\
+ S_{\rho v_\phi} &=& -2\omega_0 v_r, 
+\f}
+and if doing non-isothermal simulations the fictitious work due to the centrifugal force will be added
+\f[
+S_e = \rho v_r r \omega_0**2.
+\f]
+
+## Spherical coordinates
+
+The extra fictitious sources added to the momentum equations:
+\f{eqnarray*}{
+ S_{\rho v_r}  &=& 2\omega_0 v_\phi \sin \theta + r (\omega_0 \sin \theta)**2, \\
+ S_{\rho v_\theta} &=& \cot \theta \left[ 2\omega_0 v_\phi \sin \theta + r (\omega_0 \sin \theta)**2 \right], \\
+ S_{\rho v_\phi} &=& -2\omega_0 \sin \theta (v_r + v_\theta \cot \theta), 
+\f}
+and if doing non-isothermal simulations the fictitious work due to the centrifugal force will be added
+\f[
+S_e = \rho r (\omega_0 \sin \theta)**2 (v_r + v_\theta \cot \theta).
+\f]
+
+# Practical use
+In order to activate the addition of fictitious forces, the user has to adjust the .par file as indicated in this section. For applications of the rotating frame physics, see the `CAKwind_spherical_2.5D` test problem in the HD tests folder or the `icarus` test problem in the MHD tests folder.
+
+## Activating the module
+Depending whether the setup is in HD, MHD, or RHD the rotating frame needs to be activated in the physics-dependent namelist. This means that for a HD simulation one adds in the `&hd_list` the following:
+```
+&hd_list
+  hd_rotating_frame = .true.
+/
+```
+and a similar procedure applies when employing the `&mhd_list` or `&rhd_list`. Additionally, a `&rotating_frame_list` list has to be supplied with the (dimensionless) angular frequency of the frame:
+```
+&rotating_frame_list
+  omega_frame = DOUBLE
+/
+```
+This value can be overwritten with a computed value in the mod_usr.t if the uniform angular frequency happens to depend on other user input parameters.
+
+# Numerics and implementation
+
+The rotating frame physics module is found in mod_rotating_frame.t. This module has some subroutines that are called in the mod_hd_phys.t, mod_mhd_phys.t, and mod_rhd_phys.t module to allow to initialise, compute, and add the fictitious forces to the physics governing equations.
+
+## Primary subroutines
+
+*rotating_frame_add_source:*
+This subroutine computes the Coriolis and centrifugal contributions to the components of the momentum equation and the energy equation. Based on the geometry (cylindrical or spherical) and the problem dimension the source terms can assume different appearances.
+

--- a/doc/smallvalues.md
+++ b/doc/smallvalues.md
@@ -7,7 +7,7 @@ When doing full hydrodynamic (HD) or MHD simulations, the density on the mesh `w
 
 ## Default settings: fix nothing, check nothing, and stop when negative pressure error occurs.
 
-For HD and MHD, the default behavior to handle negative or small density/pressure values is controlled by the settings
+For HD and MHD, the default behaviour to handle negative or small density/pressure values is controlled by the settings
 
 
 ```fortran
@@ -28,7 +28,7 @@ These default settings are initialized in various places, e.g. `check_small_valu
 
 This particular default setting means that we NEVER do any artificial fix of positivity (since `fix_small_values=F`), assuming everything works as physically expected, and we only do a check on getting a positive pressure deduced each time we use the `phys_get_pthermal` subroutine (i.e. hd_get_pthermal or mhd_get_pthermal). Pressure positivity (actually p<small_pressure) is ALWAYS checked in that subroutine (thanks to `check_small_values=T`), and if we encounter p<small_pressure, an error is thrown with some info on its location. The code is then halted and forced to save the last timestep available, for possible debug analysis.
 
-It is to be noted that this default setting is usually sufficient for most practical simulations. It also helps signaling possible implementation errors in user-coded initial conditions: the idea is obviously that you initialize with physically correct conservative values in all grid cells, for which the corresponding primitive variables are all positive. The same must be true for the ghost cells. If the code signals a negative pressure error within the first timestep, or after a few tens of timesteps, first scrutinize your own initial and boundary conditions for mistakes. If they are physically meaningful, and the code can set several 1000 or so timesteps without triggering any error, you are probably doing fine, and may proceed to activate possible non-default settings as described next.
+It is to be noted that this default setting is usually sufficient for most practical simulations. It also helps signalling possible implementation errors in user-coded initial conditions: the idea is obviously that you initialize with physically correct conservative values in all grid cells, for which the corresponding primitive variables are all positive. The same must be true for the ghost cells. If the code signals a negative pressure error within the first timestep, or after a few tens of timesteps, first scrutinize your own initial and boundary conditions for mistakes. If they are physically meaningful, and the code can set several 1000 or so timesteps without triggering any error, you are probably doing fine, and may proceed to activate possible non-default settings as described next.
 
 ## Level one bootstrapping: artificially fix/replace small pressure, only when needed.
 
@@ -43,7 +43,7 @@ If the code eventually (after thousands of steps without problem) throws an erro
   small_density=1.0d-12
 /
 ```
-This setting will replace the deduced pressure in `phys_get_pthermal` by the small but positive `small_pressure` whenever the deduced pressure would end up below it. This sometimes suffices to fix and continue a run without further issue. Keeping the `small_values_method='error'` in combination with the `fix_small_values=T` implies that now, in various places throughout the code, positivity checks will become activated (all using the `small_pressure` and `small_density` values), and again errors will be thrown to stop the code if needed. 
+This setting will replace the deduced pressure in `phys_get_pthermal` by the small but positive `small_pressure` whenever the deduced pressure would end up below it. This sometimes suffices to fix and continue a run without further issue. Keeping the ``small_values_method='error'`` in combination with the `fix_small_values=T` implies that now, in various places throughout the code, positivity checks will become activated (all using the `small_pressure` and `small_density` values), and again errors will be thrown to stop the code if needed.
 
 ## Level two bootstrapping: activate a small-values treatment, and hope for the best.
 
@@ -59,11 +59,11 @@ If the previous setting did not yet fully solve your problem, and you are certai
 /
 ```
 
-This activates a (much) more aggressive fixing of negative pressure (density) instances, and in reality will replace pressure and density values with their input floor values `small_density` and `small_pressure`. Due to `fix_small_values=T`, this now happens in several locations, so not only in the `phys_get_pthermal` subroutine. E.g. it happens when converting conservative to primitive variables, at the end of the `phys_to_primitive` subroutine. What exactly is done to fix things is controlled in the `phys_handle_small_values` subroutine, which has an HD and an MHD version. If `small_values_method\='ignore'`, we check and flag erronous entries, to be 'corrected' or reported further on. The actually implemented checks are found in the `hd_check_w` or `mhd_check_w` instances, using `small_pressure` and `small_density`.
+This activates a (much) more aggressive fixing of negative pressure (density) instances, and in reality will replace pressure and density values with their input floor values `small_density` and `small_pressure`. Due to `fix_small_values=T`, this now happens in several locations, so not only in the `phys_get_pthermal` subroutine. E.g. it happens when converting conservative to primitive variables, at the end of the `phys_to_primitive` subroutine. What exactly is done to fix things is controlled in the `phys_handle_small_values` subroutine, which has an HD and an MHD version. If ``small_values_method='ignore'``, we check and flag erroneous entries, to be 'corrected' or reported further on. The actually implemented checks are found in the `hd_check_w` or `mhd_check_w` instances, using `small_pressure` and `small_density`.
 
 The `small_values_method` can be one of 'replace' or 'average', and the latter 'average' variant uses a kind of buffer zone (with a width controlled by `small_values_daverage=1`) to average info from surrounding cells that are physically ok, to replace the faulty cell. This averaging approach works best on primitive variables directly.
 
-In the `replace` variant, different behaviors can be enforced by the logicals `small_values_fix_iw(1:nw)`: these are normally all set to T, meaning that a small density will also nullify momenta and set the pressure to `small_pressure` (hence internal energy density to `small_e`). You are sort of personally responsible for finding out which (if any) combination and fixing variant works best.
+In the `replace` variant, different behaviours can be enforced by the logicals `small_values_fix_iw(1:nw)`: these are normally all set to T, meaning that a small density will also nullify momenta and set the pressure to `small_pressure` (hence internal energy density to `small_e`). You are sort of personally responsible for finding out which (if any) combination and fixing variant works best.
 
 # Debug options
 

--- a/tests/hd/CAKwind_spherical_1D/mod_usr.t
+++ b/tests/hd/CAKwind_spherical_1D/mod_usr.t
@@ -181,12 +181,12 @@ contains
     ! Small offset (~vtherm/vinf) to avoid starting at terminal wind speed
     sfac = 1.0d0 - 1.0d-3**(1.0d0/beta)
 
-    where (x(ixI^S,1) >= rstar)
-       w(ixI^S,mom(1)) = vinf * ( 1.0d0 - sfac * rstar / x(ixI^S,1) )**beta
-       w(ixI^S,rho_) = mdot / (4.0d0*dpi * x(ixI^S,1)**2.0d0 * w(ixI^S,mom(1)))
-    endwhere
+    w(ixO^S,mom(1)) = vinf * ( 1.0d0 - sfac * rstar / x(ixO^S,1) )**beta
+    w(ixO^S,rho_)   = mdot / (4.0d0*dpi * x(ixO^S,1)**2.0d0 * w(ixO^S,mom(1)))
 
-    if (hd_energy) w(ixI^S,p_) = w(ixI^S,rho_)
+    if (hd_energy) then
+      w(ixO^S,p_) = asound**2.0 * rhobound * (w(ixO^S,rho_)/rhobound)**hd_gamma
+    endif
 
     call hd_to_conserved(ixI^L,ixO^L,w,x)
 
@@ -226,7 +226,9 @@ contains
       w(ixB^S,mom(1)) = min(w(ixB^S,mom(1)), asound)
       w(ixB^S,mom(1)) = max(w(ixB^S,mom(1)), -asound)
 
-      if (hd_energy) w(ixB^S,p_) = asound**2.0d0 * w(ixB^S,rho_)
+      if (hd_energy) then
+        w(ixB^S,p_) = asound**2.0 * rhobound * (w(ixB^S,rho_)/rhobound)**hd_gamma
+      endif
 
       call hd_to_conserved(ixI^L,ixI^L,w,x)
 
@@ -240,7 +242,9 @@ contains
         w(ir,mom(1)) = w(ir-1,mom(1)) + (w(ixBmin1-1,mom(1)) - w(ixBmin1-2,mom(1)))
       enddo
 
-      if (hd_energy) w(ixB^S,p_) = asound**2.0d0 * w(ixB^S,rho_)
+      if (hd_energy) then
+        w(ixB^S,p_) = asound**2.0 * rhobound * (w(ixB^S,rho_)/rhobound)**hd_gamma
+      endif
 
       call hd_to_conserved(ixI^L,ixI^L,w,x)
 

--- a/tests/hd/CAKwind_spherical_2.5D/amrvac_energy.par
+++ b/tests/hd/CAKwind_spherical_2.5D/amrvac_energy.par
@@ -1,0 +1,84 @@
+!==================================================
+! Project : 2.5D adiabatic CAK wind
+!
+! Aim     : Include energy effects in wind outflow
+!
+! Config  : setup.pl -d=2
+!===================================================
+
+&filelist
+  base_filename = 'test/cakenergy'
+  saveprim      = .true.
+  autoconvert   = .true.
+  convert_type  = 'vtuBCCmpi'
+/
+
+&savelist
+  itsave(1,1)  = 0
+  itsave(1,2)  = 0
+  ditsave_log  = 1000
+  dtsave_dat   = 1.0d-2
+/
+
+&stoplist
+  dtmin    = 1.0d-12
+  time_max = 0.5d0
+/
+
+&methodlist
+  time_stepper = 'twostep'
+  flux_scheme  = 'tvdlf'
+  limiter      = 'vanleer'
+/
+
+&boundlist
+  ! rho, mom1, mom2, mom3, e
+  typeboundary_min1 = 5*'special'
+  typeboundary_max1 = 5*'cont'
+  typeboundary_min2 = 'symm','symm','asymm','asymm','symm'
+  typeboundary_max2 = 'symm','symm','asymm','asymm','symm'
+/
+
+&meshlist
+  domain_nx1         = 200
+  domain_nx2         = 120
+  block_nx1          = 50
+  block_nx2          = 20
+  xprobmin1          = 1.0d0
+  xprobmax1          = 10.0d0
+  xprobmin2          = 0.0d0
+  xprobmax2          = 0.5d0
+  stretch_dim(1)     = 'uni'
+  qstretch_baselevel = 1.022
+/
+
+&paramlist
+  courantpar = 0.3d0 
+/
+
+&hd_list
+  hd_gravity = .true.
+  hd_energy  = .true.
+  hd_gamma   = 1.66667d0
+  hd_cak_force = .true.
+  hd_rotating_frame = .false.
+/
+
+&rotating_frame_list
+  omega_frame = 1.0d0
+/
+
+&cak_list
+  cak_alpha    = 0.65d0
+  gayley_qbar  = 2000.0d0
+  cak_1d_force = .true.
+/
+
+&star_list
+  mstar    = 50.0d0
+  rstar    = 20.0d0
+  twind    = 4.0d4
+  rhobound = 2.0d-11
+  beta     = 0.5d0
+  Wrot     = 0.5d0
+/

--- a/tests/hd/CAKwind_spherical_2.5D/amrvac_rotating_frame.par
+++ b/tests/hd/CAKwind_spherical_2.5D/amrvac_rotating_frame.par
@@ -1,0 +1,84 @@
+!===============================================
+! Project : 2.5D CAK wind with vector force
+!
+! Aim     : study effect of (vector) line force
+!           in fast rotating OB-stars in the
+!           co-rotating frame of reference
+!
+! Config  : setup.pl -d=2
+!===============================================
+
+&filelist
+  base_filename = 'test/cakrotframe'
+  saveprim      = .true.
+  autoconvert   = .true.
+  convert_type  = 'vtuBCCmpi'
+/
+
+&savelist
+  itsave(1,1)  = 0
+  itsave(1,2)  = 0
+  ditsave_log  = 1000
+  dtsave_dat   = 1.0d-2
+/
+
+&stoplist
+  dtmin    = 1.0d-12
+  time_max = 0.5d0
+/
+
+&methodlist
+  time_stepper = 'twostep'
+  flux_scheme  = 'tvdlf'
+  limiter      = 'vanleer'
+/
+
+&boundlist
+  ! rho, mom1, mom2, mom3
+  typeboundary_min1 = 4*'special'
+  typeboundary_max1 = 4*'cont'
+  typeboundary_min2 = 'symm','symm','asymm','asymm'
+  typeboundary_max2 = 'symm','symm','asymm','asymm'
+/
+
+&meshlist
+  domain_nx1         = 200
+  domain_nx2         = 120
+  block_nx1          = 50
+  block_nx2          = 30
+  xprobmin1          = 1.0d0
+  xprobmax1          = 10.0d0
+  xprobmin2          = 0.0d0
+  xprobmax2          = 0.5d0
+  stretch_dim(1)     = 'uni'
+  qstretch_baselevel = 1.022
+/
+
+&paramlist
+  courantpar = 0.3d0 
+/
+
+&hd_list
+  hd_gravity = .true.
+  hd_energy  = .false.
+  hd_gamma   = 1.0d0
+  hd_cak_force = .true.
+  hd_rotating_frame = .true.
+/
+
+&cak_list
+  cak_alpha    = 0.65d0
+  gayley_qbar  = 2000.0d0
+  cak_vector_force = .true.
+  nthetaray  = 6
+  nphiray    = 6
+/
+
+&star_list
+  mstar    = 50.0d0
+  rstar    = 20.0d0
+  twind    = 4.0d4
+  rhobound = 2.0d-11
+  beta     = 0.5d0
+  Wrot     = 0.5d0
+/


### PR DESCRIPTION
New updates for the CAK wind implementation:
- Several updates on adiabatic models for CAK force. 
- Extension of 2.5D CAK wind problem to also use rotating frame.
- Documentation on the rotating frame module.
- While working on the above I implemented the fictitious energy sources in mod_rotating_frame. Since commit e2f1c04914109b11dbdd362f1790b15dd643f73d already solved this, I included those changes in my version and only add here (i) a few minor format fixes in mod_rotating_frame, mainly to reflect the equations being solved, and (ii) leave out an unnecessary calculation for the rotating term in the spherical polar momentum component (since most of the rotating term can be reused from the spherical radial momentum component). 
- Few small format and weblink fixes in other docs I came across.

