### PR TITLE
Prevent makefile creation without explicit -d and -v for -d<3

### DIFF
--- a/setup.pl
+++ b/setup.pl
@@ -51,6 +51,9 @@ GetOptions(
     "help"    => \$help)
     or die("Error in command line arguments\n");
 
+if (!defined $ndim || !defined $ndir) {
+    die "Error: both -d (dimension count) and -v flags (vector count) are mandatory\n";
+}
 
 # Show help if -help is given or if there are no other arguments
 if ($help || !($ndim || $arch )) {
@@ -80,9 +83,7 @@ if ($ndim) {
 
 if ($ndir) {
     replace_regexp_file("makefile", qr/NDIR\s*[:?]?=.*/, "NDIR := $ndir");
-}else{
-    replace_regexp_file("makefile", qr/NDIR\s*[:?]?=.*/, "NDIR := $ndim");
-;}
+}
 
 if ($arch) {
     replace_regexp_file("makefile", qr/ARCH\s*[:?]?=.*/, "ARCH = $arch");

--- a/setup.pl
+++ b/setup.pl
@@ -51,8 +51,8 @@ GetOptions(
     "help"    => \$help)
     or die("Error in command line arguments\n");
 
-if (!defined $ndim || !defined $ndir) {
-    die "Error: both -d (dimension count) and -v flags (vector count) are mandatory\n";
+if ($ndim < 3 && !defined $ndir) {
+    die "Error: both -d (dimension count) and -v flags (vector count) are mandatory for -d < 3\n";
 }
 
 # Show help if -help is given or if there are no other arguments

--- a/tests/ard/ext_brusselator_2d/test.make
+++ b/tests/ard/ext_brusselator_2d/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=1
+SETUP_FLAGS := -d=2 -v=2
 TESTS := ext_bruselator_2d.log 
 
 include ../../test_rules.make

--- a/tests/ard/schnakenberg_2d/test.make
+++ b/tests/ard/schnakenberg_2d/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=3
 TESTS := imex_nonlin_adv.log
 
 include ../../test_rules.make

--- a/tests/ffhd/ring_thermal_conduction_2D/test.make
+++ b/tests/ffhd/ring_thermal_conduction_2D/test.make
@@ -1,6 +1,6 @@
 PAR_FILE := tc_ring_ffhd.par
 BASE_NAME := tc_ring_ffhd
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hll_vl
 TESTS := $(SCHEMES:%=$(BASE_NAME)_%.log)

--- a/tests/ffhd/solar_atmosphere_2D/test.make
+++ b/tests/ffhd/solar_atmosphere_2D/test.make
@@ -1,6 +1,6 @@
 PAR_FILE := solar_atm_ffhdver.par
 BASE_NAME := solar_atm_ffhdver
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hll_vl
 TESTS := $(SCHEMES:%=$(BASE_NAME)_%.log)

--- a/tests/hd/CAKwind_spherical_1D/test.make
+++ b/tests/hd/CAKwind_spherical_1D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=1
+SETUP_FLAGS := -d=1 -v=1
 SCHEME_DIR := ../../schemes
 
 SCHEMES := 3step_tvdlf_mm 3step_hll_vl 3step_hll_ko 4step_hll_mc

--- a/tests/hd/Kelvin_Helmholtz_2D/test.make
+++ b/tests/hd/Kelvin_Helmholtz_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 3step_hll_cada 4step_hll_mc 4step_hllc_ko rk4_tvdlf_cada	\
 ssprk54_hll_mp5

--- a/tests/hd/Rayleigh_Taylor_2D/test.make
+++ b/tests/hd/Rayleigh_Taylor_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc	\

--- a/tests/hd/Rayleigh_Taylor_3D/test.make
+++ b/tests/hd/Rayleigh_Taylor_3D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=33
+SETUP_FLAGS := -d=3
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/hd/Rayleigh_Taylor_particles_advect_2D/test.make
+++ b/tests/hd/Rayleigh_Taylor_particles_advect_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=22
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 TESTS := rt_2d_2step_tvdlf_mm.log rt_2d_2step_tvdmu_al.log		\
 rt_2d_3step_hll_cada.log rt_2d_4step_hll_mc.log rt_2d_4step_hllc_ko.log	\

--- a/tests/hd/Richtmyer_Meshkov_dust_2D/test.make
+++ b/tests/hd/Richtmyer_Meshkov_dust_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 TESTS := RM2D_dust_sticking.log RM2D_dust_Kwok.log
 
 include ../../test_rules.make

--- a/tests/hd/Riemann_1D/test.make
+++ b/tests/hd/Riemann_1D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=1
+SETUP_FLAGS := -d=1 -v=1
 SCHEME_DIR := ../../schemes
 
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc	\

--- a/tests/hd/Riemann_2D/test.make
+++ b/tests/hd/Riemann_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc	\

--- a/tests/hd/blast_wave_Cartesian_2D/test.make
+++ b/tests/hd/blast_wave_Cartesian_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/hd/blast_wave_Cartesian_stretched_2D/test.make
+++ b/tests/hd/blast_wave_Cartesian_stretched_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hllc_cada 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/hd/blast_wave_cylindrical_2D/test.make
+++ b/tests/hd/blast_wave_cylindrical_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hllc_cada 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/hd/blast_wave_polar_2D/test.make
+++ b/tests/hd/blast_wave_polar_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hllc_cada 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/hd/blast_wave_polar_stretched_2D/test.make
+++ b/tests/hd/blast_wave_polar_stretched_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hllc_cada 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/hd/radiative_cooling_3D/test.make
+++ b/tests/hd/radiative_cooling_3D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=33
+SETUP_FLAGS := -d=3
 SCHEME_DIR := ../../schemes
 TESTS := rc_3d_2step_tvdlf_mm.log rc_3d_2step_tvdmu_al.log		\
 rc_3d_3step_hll_cada.log rc_3d_4step_hll_mc.log rc_3d_4step_hllc_ko.log	\

--- a/tests/hd/thermal_conduction_2D/test.make
+++ b/tests/hd/thermal_conduction_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/mhd/GEM_2D/test.make
+++ b/tests/mhd/GEM_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada 3step_hlld_cada

--- a/tests/mhd/Kelvin_Helmholtz_2D/test.make
+++ b/tests/mhd/Kelvin_Helmholtz_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada 3step_hlld_cada

--- a/tests/mhd/Kelvin_Helmholtz_double_2D/test.make
+++ b/tests/mhd/Kelvin_Helmholtz_double_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada 3step_hlld_cada

--- a/tests/mhd/Longcope_Strauss_2D/test.make
+++ b/tests/mhd/Longcope_Strauss_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 3step_hll_cada 4step_hll_mc 4step_hllc_ko rk4_tvdlf_cada \
 3step_hlld_cada

--- a/tests/mhd/Orszag_Tang_2D/test.make
+++ b/tests/mhd/Orszag_Tang_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada 3step_hlld_cada

--- a/tests/mhd/blast_wave_Cartesian_2D/test.make
+++ b/tests/mhd/blast_wave_Cartesian_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hlld_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada ssprk54_hlld_mp5 mhd_internal_e mhd_hydrodynamic_e

--- a/tests/mhd/blast_wave_polar_2D/test.make
+++ b/tests/mhd/blast_wave_polar_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/mhd/blast_wave_polar_stretched_2D/test.make
+++ b/tests/mhd/blast_wave_polar_stretched_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hll_cada_ct 4step_hll_mc	\
 4step_hllc_ko rk4_tvdlf_cada ssprk54_hlld_mp5_ct

--- a/tests/mhd/convection_2D/test.make
+++ b/tests/mhd/convection_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada 3step_hlld_cada

--- a/tests/mhd/icarus/test.make
+++ b/tests/mhd/icarus/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=3
+SETUP_FLAGS := -d=3 -v=3
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm
 

--- a/tests/mhd/ring_thermal_conduction_2D/test.make
+++ b/tests/mhd/ring_thermal_conduction_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada \
  mhd_internal_e mhd_hyperbolic_thermal_conduction

--- a/tests/mhd/rotor_2D/test.make
+++ b/tests/mhd/rotor_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 3step_hll_cada 3step_hlld_cada 4step_hll_mc		\
 4step_hllc_ko rk4_tvdlf_cada ssprk54_fd_mp5 ssprk54_hll_mp5 ssprk54_hlld_mp5

--- a/tests/mhd/shock_cloud_2D/test.make
+++ b/tests/mhd/shock_cloud_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada

--- a/tests/mhd/thermal_conduction_mhd_2D/test.make
+++ b/tests/mhd/thermal_conduction_mhd_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 3step_hll_cada 3step_hll_cada_ct mhd_internal_e
 

--- a/tests/mhd/tilt_instability_2D/test.make
+++ b/tests/mhd/tilt_instability_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada ssprk54_fd_mp5 ssprk54_hll_mp5 3step_hlld_cada \

--- a/tests/multigrid/field_loop_2d/test.make
+++ b/tests/multigrid/field_loop_2d/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 TESTS := test_field_loop_2d.log
 
 include ../../test_rules.make

--- a/tests/multigrid/implicit_diffusion/test.make
+++ b/tests/multigrid/implicit_diffusion/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 TESTS := test_impl_diff_2d.log
 
 include ../../test_rules.make

--- a/tests/particles/Alfven_wave_2.5D/test.make
+++ b/tests/particles/Alfven_wave_2.5D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=3
 SCHEME_DIR := ../../schemes
 SCHEMES := 2step_tvdlf_mm 2step_tvdmu_al 3step_hll_cada 4step_hll_mc \
 4step_hllc_ko rk4_tvdlf_cada ssprk54_fd_mp5 ssprk54_hll_mp5 \

--- a/tests/rd/schnakenberg_2d/test.make
+++ b/tests/rd/schnakenberg_2d/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 TESTS := test_schnakenberg_imex.log test_schnakenberg_split.log
 
 include ../../test_rules.make

--- a/tests/rd/test_suite_2d/test.make
+++ b/tests/rd/test_suite_2d/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 TESTS := gs2d_chaos.log
 
 include ../../test_rules.make

--- a/tests/rhd/RHD_shock_1D/test.make
+++ b/tests/rhd/RHD_shock_1D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=1
+SETUP_FLAGS := -d=1 -v=1
 SCHEME_DIR := ../../schemes
 
 SCHEMES := IMEX_SP_tvdlf_ko IMEX_Trap_hll_w5

--- a/tests/rhd/RHD_wave_1D/test.make
+++ b/tests/rhd/RHD_wave_1D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=1
+SETUP_FLAGS := -d=1 -v=1
 SCHEME_DIR := ../../schemes
 
 SCHEMES := IMEX_SP_tvdlf_ko IMEX_Trap_hll_w5

--- a/tests/rho/auto_1d/test.make
+++ b/tests/rho/auto_1d/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=1
+SETUP_FLAGS := -d=1 -v=1
 SCHEME_DIR := ../../schemes
 
 SCHEMES := 1step_tvd 2step_tvdlf_mm 2step_tvdmu_al trap_hll_ko 3step_hll_cada	\

--- a/tests/rho/auto_2d/test.make
+++ b/tests/rho/auto_2d/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 
 SCHEMES := 1step_tvd 2step_tvdlf_mm 2step_tvdmu_al trap_hll_ko 3step_hll_cada	\

--- a/tests/twofl/KHI_2D/test.make
+++ b/tests/twofl/KHI_2D/test.make
@@ -1,4 +1,4 @@
-SETUP_FLAGS := -d=2
+SETUP_FLAGS := -d=2 -v=2
 SCHEME_DIR := ../../schemes
 
 SCHEMES := 3step_tvdlf_mm 3step_hll_cada 3step_hlld_cada 3step_fd_mp5


### PR DESCRIPTION
This simple request ensures that one cannot accidentally run a 2D vector problem when wanting 2.5D. Similarly for 1D problems.