### PR TITLE
Fix bug in mod_oneblock

### DIFF
--- a/src/modules/mod_oneblock.t
+++ b/src/modules/mod_oneblock.t
@@ -9,190 +9,192 @@ module mod_oneblock
   implicit none
   save
 
-  double precision, dimension({^D&:|,},:), allocatable       :: woneblock
-  double precision, dimension({^D&:|,},:), allocatable       :: xoneblock
-  integer                                                    :: nc^D
-  integer                                                    :: unit=15 !file unit to read on
+  double precision, allocatable :: woneblock({^D&:|,},:)
+  double precision, allocatable :: xoneblock({^D&:|,},:)
+
+  integer, private :: nc^D
+  integer, private :: unit=15 !file unit to read on
 
 contains
 
   subroutine read_oneblock(filename)
-  use mod_global_parameters
+    use mod_global_parameters
 
-  double precision                         :: time
-  integer                                  :: ix^D, ixp^D
-  integer                                  :: idim
-  integer,dimension(^ND)                   :: sendbuff
-  character(len=*), intent(in)             :: filename
-  character(len=1024)                      :: outfilehead
+    character(len=*), intent(in) :: filename
 
-  if (mype == 0) write(*,*) 'mod_oneblock: reading ',nw,' variables on unit:', unit
+    double precision     :: time
+    integer              :: ix^D, ixp^D, idim
+    integer              :: sendbuff(^ND)
+    character(len=1024)  :: outfilehead
 
-  !----------------------------------------
-  ! Root does the reading:
-  !----------------------------------------
-  if (mype == 0) then 
-     open(unit,file=filename,status='unknown')
-     ! The header information:
-     read(unit,'(A)') outfilehead
-     read(unit,*) nc^D
-     read(unit,*) time
-     
-     ! Allocate and read the grid and variables:
-     allocate(xoneblock(nc^D,1:^ND))
-     allocate(woneblock(nc^D,1:nw))
-     
-     {do ix^DB=1,nc^DB\}  
-     
-     read(unit,*) xoneblock(ix^D,1:^ND), woneblock(ix^D,1:nw)
-     
-     {end do\}
-     
-  ! Close the file
-     close(unit)
-  end if! mype==0
+    if (mype == 0) &
+         write(*,*) 'mod_oneblock: reading ', nw,' variables on unit:', unit
 
-  !----------------------------------------
-  ! Broadcast what mype=0 read:
-  !----------------------------------------
-  if (npe>1) then 
-     {sendbuff(^D)=nc^D;}
-     call MPI_BCAST(sendbuff,^ND,MPI_INTEGER,0,icomm,ierrmpi)
-     if (mype .ne. 0) then 
+    !----------------------------------------
+    ! Root does the reading:
+    !----------------------------------------
+    if (mype == 0) then
+      open(unit,file=filename,status='unknown')
+      ! The header information:
+      read(unit,'(A)') outfilehead
+      read(unit,*) nc^D
+      read(unit,*) time
+      
+      ! Allocate and read the grid and variables:
+      allocate(xoneblock(nc^D,1:^ND))
+      allocate(woneblock(nc^D,1:nw))
+      
+      {do ix^DB=1,nc^DB\}
+        read(unit,*) xoneblock(ix^D,1:^ND), woneblock(ix^D,1:nw)
+      {end do\}
+      
+      ! Close the file
+      close(unit)
+    end if! mype==0
+
+    !----------------------------------------
+    ! Broadcast what mype=0 read:
+    !----------------------------------------
+    if (npe > 1) then
+      {sendbuff(^D)=nc^D;}
+      call MPI_BCAST(sendbuff,^ND,MPI_INTEGER,0,icomm,ierrmpi)
+
+      if (mype /= 0) then
         {nc^D=sendbuff(^D);}
         ! Allocate the grid and variables:
         allocate(xoneblock(nc^D,1:^ND))
         allocate(woneblock(nc^D,1:nw))
-     end if
-     call MPI_BCAST(xoneblock,{nc^D|*}*^ND,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
-     call MPI_BCAST(woneblock,{nc^D|*}*nw,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
-  end if! npe>1
+      end if
+
+      call MPI_BCAST(xoneblock,{nc^D|*}*^ND,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
+      call MPI_BCAST(woneblock,{nc^D|*}*nw,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
+    end if! npe>1
 
   end subroutine read_oneblock
 
   subroutine interpolate_oneblock(x,iw,out)
 
-  double precision, dimension(^ND),intent(in)             :: x 
-  integer, intent(in)                                     :: iw
-  double precision, intent(out)                           :: out
-  ! .. local ..
-  double precision, dimension(^ND)                        :: xloc
-  double precision                                        :: xd^D
-  {^IFTWOD
-  double precision                                        :: c00, c10
-  }
-  {^IFTHREED
-  double precision                                        :: c0, c1, c00, c10, c01, c11
-  }
-  integer                                                 :: ipivot^D, idir
-  integer                                                 :: ic^D, ic1^D, ic2^D
+    double precision, intent(in)  :: x(^ND)
+    integer,          intent(in)  :: iw
+    double precision, intent(out) :: out
+    ! .. local ..
+    double precision :: xloc(^ND)
+    double precision :: xd^D
+    {^IFTWOD
+    double precision :: c00, c10
+    }
+    {^IFTHREED
+    double precision :: c0, c1, c00, c10, c01, c11
+    }
+    integer :: ipivot^D, idir
+    integer :: ic^D, ic1^D, ic2^D
 
-  xloc=x
+    xloc = x
 
-  !--------------------------------------------
-  ! Hunt for the index closest to the point
-  ! This is a bit slow but allows for stretched grids
-  ! (still need to be orthogonal for interpolation though)
-  !--------------------------------------------
-  ipivot^D=1;
-  {^IFONED
-  ic1 = minloc(dabs(xloc(1)-xoneblock(:,1)),1,mask=.true.)
-  }
-  {^IFTWOD
-  do idir = 1, ^ND
-     select case (idir)
-     case (1)
+    !--------------------------------------------
+    ! Hunt for the index closest to the point
+    ! This is a bit slow but allows for stretched grids
+    ! (still need to be orthogonal for interpolation though)
+    !--------------------------------------------
+    ipivot^D=1;
+    {^IFONED
+    ic1 = minloc(dabs(xloc(1)-xoneblock(:,1)),1,mask=.true.)
+    }
+    {^IFTWOD
+    do idir = 1, ^ND
+      select case (idir)
+      case (1)
         ic1 = minloc(dabs(xloc(1)-xoneblock(:,ipivot2,idir)),1,mask=.true.)
-     case (2)
+      case (2)
         ic2 = minloc(dabs(xloc(2)-xoneblock(ipivot1,:,idir)),1,mask=.true.)
-     case default
-        call mpistop("error1 in interpolate_oneblock")
-     end select
-  end do
-  }
-  {^IFTHREED
-  do idir = 1, ^ND
-     select case (idir)
-     case (1)
+      case default
+        call mpistop("error in interpolate_oneblock")
+      end select
+    end do
+    }
+    {^IFTHREED
+    do idir = 1, ^ND
+      select case (idir)
+      case (1)
         ic1 = minloc(dabs(xloc(1)-xoneblock(:,ipivot2,ipivot3,idir)),1, &
-             mask=.true.)
-     case (2)
+              mask=.true.)
+      case (2)
         ic2 = minloc(dabs(xloc(2)-xoneblock(ipivot1,:,ipivot3,idir)),1, &
-             mask=.true.)
-     case (3)
+              mask=.true.)
+      case (3)
         ic3 = minloc(dabs(xloc(3)-xoneblock(ipivot1,ipivot2,:,idir)),1, &
-             mask=.true.)
-     case default
-        call mpistop("error1 in interpolate_oneblock")
-     end select
-  end do
-  }
+              mask=.true.)
+      case default
+        call mpistop("error in interpolate_oneblock")
+      end select
+    end do
+    }
 
-  ! flat interpolation would simply be:
-  !out = woneblock(ic^D,iw)
-  !return
+    ! flat interpolation would simply be:
+    !out = woneblock(ic^D,iw)
+    !return
 
-  !-------------------------------------------
-  ! Get the left and right indices
-  !-------------------------------------------
-  {
-  if (xoneblock({ic^DD},^D) .lt. xloc(^D)) then
-     ic1^D = ic^D
-  else
-     ic1^D = ic^D -1
-  end if
-  ic2^D = ic1^D + 1
-  \}
+    !-------------------------------------------
+    ! Get the left and right indices
+    !-------------------------------------------
+    {
+    if (xoneblock({ic^DD},^D) < xloc(^D)) then
+      ic1^D = ic^D
+    else
+      ic1^D = ic^D -1
+    end if
+    ic2^D = ic1^D + 1
+    \}
 
-  !--------------------------------------------
-  ! apply flat interpolation if outside of range, 
-  ! change point-location to make this easy!
-  !--------------------------------------------
-  {
-  if (ic1^D .lt. 1) then
-     ic1^D = 1
-     ic2^D = ic1^D + 1
-     xloc(^D) = xoneblock(ic^DD,^D)
-  end if
-  \}
-  {
-  if (ic2^D .gt. nc^D) then
-     ic2^D = nc^D
-     ic1^D = ic2^D - 1
-     xloc(^D) = xoneblock(ic^DD,^D)
-  end if
-  \}
+    !--------------------------------------------
+    ! apply flat interpolation if outside of range,
+    ! change point-location to make this easy!
+    !--------------------------------------------
+    {
+    if (ic1^D < 1) then
+      ic1^D = 1
+      ic2^D = ic1^D + 1
+      xloc(^D) = xoneblock(ic^DD,^D)
+    end if
+    \}
+    {
+    if (ic2^D > nc^D) then
+      ic2^D = nc^D
+      ic1^D = ic2^D - 1
+      xloc(^D) = xoneblock(ic^DD,^D)
+    end if
+    \}
 
 
-  !-------------------------------------------
-  ! linear, bi- and tri- linear interpolations
-  !-------------------------------------------
-  {^IFONED
-  xd1 = (xloc(1)-xoneblock(ic11,1)) / (xoneblock(ic21,1) - xoneblock(ic11,1))
-  out = woneblock(ic11,iw) * (1.0d0 - xd1) + woneblock(ic21,iw) * xd1
-  }
-  {^IFTWOD
-  xd1 = (xloc(1)-xoneblock(ic11,ic12,1)) / (xoneblock(ic21,ic12,1) - xoneblock(ic11,ic12,1))      
-  xd2 = (xloc(2)-xoneblock(ic11,ic12,2)) / (xoneblock(ic11,ic22,2) - xoneblock(ic11,ic12,2))
-  c00 = woneblock(ic11,ic12,iw) * (1.0d0 - xd1) + woneblock(ic21,ic12,iw) * xd1
-  c10 = woneblock(ic11,ic22,iw) * (1.0d0 - xd1) + woneblock(ic21,ic22,iw) * xd1
-  out = c00 * (1.0d0 - xd2) + c10 * xd2
-  }
-  {^IFTHREED
-  xd1 = (xloc(1)-xoneblock(ic11,ic12,ic13,1)) / (xoneblock(ic21,ic12,ic13,1) - xoneblock(ic11,ic12,ic13,1))      
-  xd2 = (xloc(2)-xoneblock(ic11,ic12,ic13,2)) / (xoneblock(ic11,ic22,ic13,2) - xoneblock(ic11,ic12,ic13,2))      
-  xd3 = (xloc(3)-xoneblock(ic11,ic12,ic13,3)) / (xoneblock(ic11,ic12,ic23,3) - xoneblock(ic11,ic12,ic13,3))    
+    !-------------------------------------------
+    ! linear, bi- and tri- linear interpolations
+    !-------------------------------------------
+    {^IFONED
+    xd1 = (xloc(1)-xoneblock(ic11,1)) / (xoneblock(ic21,1) - xoneblock(ic11,1))
+    out = woneblock(ic11,iw) * (1.0d0 - xd1) + woneblock(ic21,iw) * xd1
+    }
+    {^IFTWOD
+    xd1 = (xloc(1)-xoneblock(ic11,ic12,1)) / (xoneblock(ic21,ic12,1) - xoneblock(ic11,ic12,1))
+    xd2 = (xloc(2)-xoneblock(ic11,ic12,2)) / (xoneblock(ic11,ic22,2) - xoneblock(ic11,ic12,2))
+    c00 = woneblock(ic11,ic12,iw) * (1.0d0 - xd1) + woneblock(ic21,ic12,iw) * xd1
+    c10 = woneblock(ic11,ic22,iw) * (1.0d0 - xd1) + woneblock(ic21,ic22,iw) * xd1
+    out = c00 * (1.0d0 - xd2) + c10 * xd2
+    }
+    {^IFTHREED
+    xd1 = (xloc(1)-xoneblock(ic11,ic12,ic13,1)) / (xoneblock(ic21,ic12,ic13,1) - xoneblock(ic11,ic12,ic13,1))
+    xd2 = (xloc(2)-xoneblock(ic11,ic12,ic13,2)) / (xoneblock(ic11,ic22,ic13,2) - xoneblock(ic11,ic12,ic13,2))
+    xd3 = (xloc(3)-xoneblock(ic11,ic12,ic13,3)) / (xoneblock(ic11,ic12,ic23,3) - xoneblock(ic11,ic12,ic13,3))
 
-  c00 = woneblock(ic11,ic12,ic13,iw) * (1.0d0 - xd1) + woneblock(ic21,ic12,ic13,iw) * xd1
-  c10 = woneblock(ic11,ic22,ic13,iw) * (1.0d0 - xd1) + woneblock(ic21,ic22,ic13,iw) * xd1
-  c01 = woneblock(ic11,ic12,ic23,iw) * (1.0d0 - xd1) + woneblock(ic21,ic12,ic23,iw) * xd1
-  c11 = woneblock(ic11,ic22,ic23,iw) * (1.0d0 - xd1) + woneblock(ic21,ic22,ic23,iw) * xd1
+    c00 = woneblock(ic11,ic12,ic13,iw) * (1.0d0 - xd1) + woneblock(ic21,ic12,ic13,iw) * xd1
+    c10 = woneblock(ic11,ic22,ic13,iw) * (1.0d0 - xd1) + woneblock(ic21,ic22,ic13,iw) * xd1
+    c01 = woneblock(ic11,ic12,ic23,iw) * (1.0d0 - xd1) + woneblock(ic21,ic12,ic23,iw) * xd1
+    c11 = woneblock(ic11,ic22,ic23,iw) * (1.0d0 - xd1) + woneblock(ic21,ic22,ic23,iw) * xd1
 
-  c0  = c00 * (1.0d0 - xd2) + c10 * xd2
-  c1  = c01 * (1.0d0 - xd2) + c11 * xd2
+    c0  = c00 * (1.0d0 - xd2) + c10 * xd2
+    c1  = c01 * (1.0d0 - xd2) + c11 * xd2
 
-  out = c0 * (1.0d0 - xd3) + c1 * xd3
-  }
+    out = c0 * (1.0d0 - xd3) + c1 * xd3
+    }
 
   end subroutine interpolate_oneblock
 

--- a/src/modules/mod_oneblock.t
+++ b/src/modules/mod_oneblock.t
@@ -20,7 +20,7 @@ contains
   use mod_global_parameters
 
   double precision                         :: time
-  integer                                  :: nctot, ix^D, ixp^D
+  integer                                  :: ix^D, ixp^D
   integer                                  :: idim
   integer,dimension(^ND)                   :: sendbuff
   character(len=*), intent(in)             :: filename
@@ -35,7 +35,7 @@ contains
      open(unit,file=filename,status='unknown')
      ! The header information:
      read(unit,'(A)') outfilehead
-     read(unit,*) nctot,nc^D
+     read(unit,*) nc^D
      read(unit,*) time
      
      ! Allocate and read the grid and variables:


### PR DESCRIPTION
Reading in of oneblock file still relies on total number of cells input. This is information is not present in the oneblock files any more. This leads to a crash upon reading in oneblock file. Now fixed. Also clean mod_oneblock for better readability