### PR TITLE
style: remove the block construct and fix the ambipolar test boundary…

### DIFF
--- a/src/physics/mod_thermal_emission.t
+++ b/src/physics/mod_thermal_emission.t
@@ -1281,6 +1281,7 @@ module mod_thermal_emission
       double precision :: pth(ixI^S),Te(ixI^S),kbT(ixI^S)
       double precision :: Ne(ixI^S),gff(ixI^S),fi(ixI^S)
       double precision :: EM(ixI^S)
+      double precision :: nH_dummy(ixI^S)
 
       I0=3.01d-15   ! I0*4*pi*AU**2, I0 from Pinto (2015)
       kb=const_kb
@@ -1292,10 +1293,7 @@ module mod_thermal_emission
       call fl%get_var_Rfactor(w,x,ixI^L,ixO^L,Te)
       Te(ixO^S)=pth(ixO^S)/(Ne(ixO^S)*Te(ixO^S))*unit_temperature
       ! get actual electron density from EoS (replaces rho with ne)
-      block
-        double precision :: nH_dummy(ixI^S)
-        call eos%get_ne_nH(ixI^L, ixO^L, w, x, Ne, nH_dummy)
-      end block
+      call eos%get_ne_nH(ixI^L, ixO^L, w, x, Ne, nH_dummy)
       if (SI_unit) then
         Ne(ixO^S)=Ne(ixO^S)*unit_numberdensity/1.d6 ! m^-3 -> cm-3
         EM(ixO^S)=(Ne(ixO^S))**2*1.d6 ! cm^-3 m^-3
@@ -1365,6 +1363,7 @@ module mod_thermal_emission
       double precision :: I0,kb,keV,dE,Ei,El,Eu,A_cgs
       double precision :: pth(ixI^S),Te(ixI^S),kbT(ixI^S)
       double precision :: Ne(ixI^S),EM(ixI^S)
+      double precision :: nH_dummy(ixI^S)
       double precision :: gff,fi,erg_SI
 
       ! check whether the grid is inside given box
@@ -1392,10 +1391,7 @@ module mod_thermal_emission
         call fl%get_var_Rfactor(w,x,ixI^L,ixb^L,Te)
         Te(ixb^S)=pth(ixb^S)/(Ne(ixb^S)*Te(ixb^S))*unit_temperature
         ! get actual electron density from EoS (replaces rho with ne)
-        block
-          double precision :: nH_dummy(ixI^S)
-          call eos%get_ne_nH(ixI^L, ixb^L, w, x, Ne, nH_dummy)
-        end block
+        call eos%get_ne_nH(ixI^L, ixb^L, w, x, Ne, nH_dummy)
         if (SI_unit) then
           Ne(ixO^S)=Ne(ixO^S)*unit_numberdensity/1.d6 ! m^-3 -> cm-3
           EM(ixb^S)=(I0*(Ne(ixb^S))**2)*dV(ixb^S)*(unit_length*1.d2)**3 ! cm^-3
@@ -6290,7 +6286,7 @@ module mod_thermal_emission
       double precision, intent(inout) :: WLB(numXI1,numXI2,numWI)
 
       integer :: ixO^L,ixO^D,ixI^L,ix^D,i,j
-      double precision, allocatable :: flux(:^D&),Ne(:^D&)
+      double precision, allocatable :: flux(:^D&),Ne(:^D&),nH_dummy(:^D&)
       integer :: ixP^L,ixP^D,nSubC^D,iSubC^D
       double precision :: xSubP1,xSubP2,dxSubP,xerf^L,fluxsubC,RsubC
       double precision :: sigma_PSF,sigma0,arcsec,pixel,LASCO_rsl
@@ -6313,6 +6309,7 @@ module mod_thermal_emission
       endif
 
       allocate(Ne(ixI^S))
+      allocate(nH_dummy(ixI^S))
       if (whitelight_instrument=='LASCO/C1') then
         LASCO_rsl=5.6d0/instrument_resolution_factor
         R_occult=1.1d0
@@ -6327,10 +6324,7 @@ module mod_thermal_emission
       R_occult=R_occult*const_Rsun/unit_length
       call fl%get_rho(ps(igrid)%w,ps(igrid)%x,ixI^L,ixO^L,Ne)
       ! get actual electron density from EoS (replaces rho with ne)
-      block
-        double precision :: nH_dummy(ixI^S)
-        call eos%get_ne_nH(ixI^L, ixO^L, ps(igrid)%w, ps(igrid)%x, Ne, nH_dummy)
-      end block
+      call eos%get_ne_nH(ixI^L, ixO^L, ps(igrid)%w, ps(igrid)%x, Ne, nH_dummy)
       sigma_PSF=1.d0
       pixel=LASCO_rsl*arcsec
       sigma0=sigma_PSF*pixel
@@ -6415,6 +6409,7 @@ module mod_thermal_emission
       {enddo\} !ix
 
       deallocate(Ne)
+      deallocate(nH_dummy)
 
     end subroutine integrate_whitelight_spherical
 

--- a/src/physics/mod_trace_field.t
+++ b/src/physics/mod_trace_field.t
@@ -10163,8 +10163,12 @@ contains
     double precision :: dxc^D,xd^D
     double precision :: field(0:1^D&,ndir),Fx(ndim),factor(0:1^D&)
     double precision :: Ftotal,field_min
+    double precision :: w_stencil(0:1^D&,1:nw)
+    double precision :: x_stencil(0:1^D&,1:ndim)
+    double precision :: vector_stencil(0:1^D&,1:ndir)
     logical :: valid_field
     integer          :: ixb^D,ix^D,ixbl^D,j,status_interp
+    integer          :: ixS^L
 
     if (geo_coordinate==geo_spherical) then
       call trace_interp_weights_block(xfn,igrid,ixI^L,ixbl^D,xd^D,dxc^D, &
@@ -10198,21 +10202,16 @@ contains
         {enddo\}
       endif
     else if (ftype=='Vfield') then
-      block
-        double precision :: w_stencil(ixbl^D:ixbl^D+1^D&,1:nw)
-        double precision :: x_stencil(ixbl^D:ixbl^D+1^D&,1:ndim)
-        double precision :: vector_stencil(ixbl^D:ixbl^D+1^D&,1:ndir)
-        integer :: ixS^L
-
-        ^D&ixSmin^D=ixbl^D;
-        ^D&ixSmax^D=ixbl^D+1;
-        w_stencil(ixS^S,1:nw)=ps(igrid)%w(ixS^S,1:nw)
-        x_stencil(ixS^S,1:ndim)=ps(igrid)%x(ixS^S,1:ndim)
-        call phys_get_v(w_stencil,x_stencil,ixS^L,ixS^L,vector_stencil)
-        {do ix^D=0,1\}
-          field(ix^D,1:ndir)=vector_stencil(ixbl^D+ix^D,1:ndir)
-        {enddo\}
-      end block
+      ! stencil is the two cells ixbl:ixbl+1 in each direction, held at 0:1 so
+      ! the bounds do not depend on the runtime ixbl
+      ^D&ixSmin^D=0;
+      ^D&ixSmax^D=1;
+      w_stencil(ixS^S,1:nw)=ps(igrid)%w(ixbl^D:ixbl^D+1^D&,1:nw)
+      x_stencil(ixS^S,1:ndim)=ps(igrid)%x(ixbl^D:ixbl^D+1^D&,1:ndim)
+      call phys_get_v(w_stencil,x_stencil,ixS^L,ixS^L,vector_stencil)
+      {do ix^D=0,1\}
+        field(ix^D,1:ndir)=vector_stencil(ix^D,1:ndir)
+      {enddo\}
     endif
     {do ix^D=0,1\}
       factor(ix^D)={abs(1-ix^D-xd^D)*}

--- a/tests/demo/AmbipolarMHD_fastwave_1D/mod_usr.t
+++ b/tests/demo/AmbipolarMHD_fastwave_1D/mod_usr.t
@@ -990,10 +990,10 @@ end  subroutine special_process_filter
 
 
 
-  subroutine specialbound_usr(qt,ixI^L,ixO^L,iB,w,x)
+  subroutine specialbound_usr(qdt,qt,ixI^L,ixO^L,iB,w,x)
     ! special boundary types, user defined
     integer, intent(in) :: ixO^L, iB, ixI^L
-    double precision, intent(in) :: qt, x(ixI^S,1:ndim)
+    double precision, intent(in) :: qdt, qt, x(ixI^S,1:ndim)
     double precision, intent(inout) :: w(ixI^S,1:nw)
 
 

--- a/tests/mhd/icarus/mod_usr.t
+++ b/tests/mhd/icarus/mod_usr.t
@@ -702,12 +702,10 @@ contains
         end do
 
       case (AMR_LONWINDOW)
-        ! refine if any cell is within fixed window around φ0 (wrap-safe)
-        block
-          if (any( abs( modulo((x(ixI^S,3)-phi0)+dpi, 2.d0*dpi)-dpi ) <= halfw )) then
-            refine=1; coarsen=-1
-          end if
-        end block
+        ! refine if any cell is within fixed window around phi0 (wrap-safe)
+        if (any( abs( modulo((x(ixI^S,3)-phi0)+dpi, 2.d0*dpi)-dpi ) <= halfw )) then
+          refine=1; coarsen=-1
+        end if
 
       case (AMR_TRACING)
 


### PR DESCRIPTION
… signature

block is the name of the global state pointer, so the fortran block construct collides with the most-used identifier in the tree and hides declarations inside executable code. Five occurrences are replaced by ordinary declarations in the enclosing routine.

get_SXR and get_GOES_flux_grid size nH_dummy from a dummy argument, so the automatic array hoists unchanged. integrate_whitelight_spherical sizes it from a local set at runtime, so it becomes allocatable and is allocated beside Ne. get_K in mod_trace_field held its stencils at ixbl:ixbl+1 with ixbl a runtime local; the extent is always two, so the arrays now use the 0:1 bounds the routine already uses for field and the offset moves into the copy. The icarus refinement case wrapped a bare if in a block with no declarations at all.

specialbound_usr in the ambipolar test still had the pre-qdt signature and so failed to compile against the special_bc interface. It is the only test that sets has_equi_rho_and_p, which is why nothing was exercising equilibrium splitting.

One non-ascii character in the icarus comment is replaced while editing that line.